### PR TITLE
Add start to overview redirect to sandbox docs

### DIFF
--- a/packages/sandbox-docs/next.config.js
+++ b/packages/sandbox-docs/next.config.js
@@ -22,6 +22,11 @@ module.exports = withTM(
           destination: "/overview",
           permanent: true,
         },
+        {
+          source: "/start",
+          destination: "/overview",
+          permanent: false,
+        },
       ];
     },
   })


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/fervent-payne">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/fervent-payne">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

I found some links that actually are pointing to `docs/start`. Let's add a not permanent redirect to it.