### PR TITLE
Fix broken api link with a redirection to /api-reference

### DIFF
--- a/packages/sandbox-docs/next.config.js
+++ b/packages/sandbox-docs/next.config.js
@@ -27,6 +27,11 @@ module.exports = withTM(
           destination: "/overview",
           permanent: false,
         },
+        {
+          source: "/api",
+          destination: "/api-reference",
+          permanent: false,
+        },
       ];
     },
   })


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/vigilant-cache">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/vigilant-cache">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

