### PR TITLE
Fix spelling mistake

### DIFF
--- a/packages/projects-docs/pages/learn/setting-up/secrets.md
+++ b/packages/projects-docs/pages/learn/setting-up/secrets.md
@@ -16,7 +16,7 @@ Configure environment variables and secrets in your project, such as settings fo
 
 Currently CodeSandbox Projects only supports **project-level** configuration. The secrets and environment variables are shared across all VMs, but it's necessary to restart your workspace after making changes for them to take effect.
 
-### Storage and Encription
+### Storage and Encryption
 
 Environment variables are stored in our database, AES encrypted. The encryption key is rerolled from time to time on an unannounced schedule and the key is stored separately from the database.
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/fix/encryption-spelling-mistake">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=fix/encryption-spelling-mistake">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

Fix for spelling `encryption`