### PR TITLE
docs(faq): make the Node version suggested in FAQ consistent

### DIFF
--- a/packages/sandbox-docs/pages/faq.md
+++ b/packages/sandbox-docs/pages/faq.md
@@ -52,7 +52,7 @@ recommend using a container sandbox.
 
 ## Can I change the Node version used in a container sandbox?
 
-Yes. Container sandboxes run Node v10.20.1 (LTS) by default. However, you can
+Yes. Container sandboxes run [Node (LTS)](https://nodejs.org/en/about/releases/) by [default](https://codesandbox.io/docs/configuration#sandbox-configuration). However, you can
 specify a `node` value to alter the version in `sandbox.config.json`, which will
 be used instead. For further details, see [configuration](/docs/configuration).
 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/oscard0m/docs/patch-1?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=oscard0m&repo=docs&branch=patch-1">VS Code</a>

<!-- open-in-codesandbox:complete -->


with configuration docs