### PR TITLE
Update open git panel shortcut

### DIFF
--- a/packages/projects-docs/pages/learn/editor/shortcuts.md
+++ b/packages/projects-docs/pages/learn/editor/shortcuts.md
@@ -9,7 +9,7 @@ description:
 
 | Shortcut      | Description |
 | ----------- | ----------- |
-⌘ ⇧ G or ⌃ O then G     |   Open git panel
+⌃ ⇧ G     |   Open git panel
 ⌃ ⌥ X       |   Close other files
 ⌘ ⌥ M       |   New folder
 ⌘ ⇧ E or ⌃ O then A     |   Open file system panel


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/vigilant-matsumoto">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/vigilant-matsumoto">VS Code</a>

<!-- codesandbox/open-in-codesandbox:complete -->

When the shortcut has been updated in projects we need to update the docs page.