### PR TITLE
Add reference to GitHub App Page

### DIFF
--- a/packages/projects-docs/pages/learn/integrations/github-app.md
+++ b/packages/projects-docs/pages/learn/integrations/github-app.md
@@ -12,6 +12,7 @@ The integration of CodeSandbox and GitHub allows you to automatically add links 
 ![GitHub and CodeSandbox Integration](../images/GH-App-integration.jpg)
 
 
+
 #### Open Preview
 This link will start up a stand-alone devtool that spins up the preview link.
 
@@ -32,6 +33,8 @@ After the installation request is made, the owner of the repository or an admin 
 
 - Installation request that appears when importing a repo for the first time.
 - GitHub alls can be installed on an organization level or for individual repositories
+
+Alternatively, you can also configure the app through it's official [GitHub App Page](https://github.com/apps/codesandbox)
 
 ## Privacy and Permissions
 The GitHub App allows CodeSandbox to retrieve some information about your GitHub account and, in some circumstances, to make changes on GitHub on your behalf. 


### PR DESCRIPTION
<img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/competent-panini?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/competent-panini">VS Code</a>

<!-- open-in-codesandbox:complete -->


<img width="596" alt="image" src="https://user-images.githubusercontent.com/1887455/183689763-a7021e0f-6fe4-4fb8-ae46-962a5e571c20.png">

Added link to the GitHub App Page in the Docs - https://github.com/apps/codesandbox