### PR TITLE
chore: enable preview link for vscode docs

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -59,7 +59,11 @@
     "dev:vscode": {
       "name": "Dev VS code",
       "command": "pnpm dev:vscode",
-      "runAtStart": false
+      "runAtStart": true,
+      "preview": {
+        "port": 3002,
+        "prLink": "devtool"
+      }
     },
     "dev:ios": {
       "name": "Dev iOS",


### PR DESCRIPTION
<details>
<summary><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/silly-cookies?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/silly-cookies">VS Code</a></summary>
<ul><li><a href="https://codesandbox.io/p/devtool/preview/cd5szq?task=dev:projects&port=3001">Dev Projects</a></li><li><a href="https://codesandbox.io/p/devtool/preview/cd5szq?task=dev:sandbox&port=3000">Dev Sandbox</a></li><li><a href="https://codesandbox.io/p/devtool/preview/cd5szq?task=dev:vscode&port=3002">Dev VS code</a></li></ul>
</details>

<!-- open-in-codesandbox:complete -->


