### PR TITLE
fix(docker-tutorial): broken image and alt text

### DIFF
--- a/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
+++ b/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
@@ -13,15 +13,15 @@ In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that tak
 
 ### 1. Click on the add a devtool dropdown
 
-![https://images.tango.us/public/screenshot_2cd6a519-514d-48d2-b75d-2a88f700d38c.png?crop=focalpoint&fit=crop&fp-x=0.8471&fp-y=0.0160&fp-z=3.2192&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_2cd6a519-514d-48d2-b75d-2a88f700d38c.png?crop=focalpoint&fit=crop&fp-x=0.8471&fp-y=0.0160&fp-z=3.2192&w=1200&ar=3892%3A3008)
+![Pressing the add devtool button shows a dropdown with the different devtools you can add.](https://images.tango.us/public/screenshot_2cd6a519-514d-48d2-b75d-2a88f700d38c.png?crop=focalpoint&fit=crop&fp-x=0.8471&fp-y=0.0160&fp-z=3.2192&w=1200&ar=3892%3A3008)
 
 ### 2. Open a new terminal
 
-![https://images.tango.us/public/screenshot_1e72d8f1-3ea5-4219-941b-98bbd2e25c2a.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.1509&fp-z=3.0619&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_1e72d8f1-3ea5-4219-941b-98bbd2e25c2a.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.1509&fp-z=3.0619&w=1200&ar=3892%3A3008)
+![When selecting the terminal devtool option in the dropdown a sub menu shows up with the option to add a new terminal.](https://images.tango.us/public/screenshot_1e72d8f1-3ea5-4219-941b-98bbd2e25c2a.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.1509&fp-z=3.0619&w=1200&ar=3892%3A3008)
 
 ### 3. Run a docker image
 
-![https://images.tango.us/public/screenshot_e4ebb65d-2dc2-4560-84eb-df5d1296dfcb.png?crop=focalpoint&fit=crop&fp-x=0.7255&fp-y=0.2595&fp-z=1.9255&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_e4ebb65d-2dc2-4560-84eb-df5d1296dfcb.png?crop=focalpoint&fit=crop&fp-x=0.7255&fp-y=0.2595&fp-z=1.9255&w=1200&ar=3892%3A3008)
+![Inside the terminal a command is pasted to run the docker image.](https://images.tango.us/public/screenshot_e4ebb65d-2dc2-4560-84eb-df5d1296dfcb.png?crop=focalpoint&fit=crop&fp-x=0.7255&fp-y=0.2595&fp-z=1.9255&w=1200&ar=3892%3A3008)
 
 ### 4. Opened ports will be picked up automatically
 
@@ -31,11 +31,11 @@ If you run a development server for example inside the container and it opens up
 
 ### 5. If you would like to start the given container every time you create a new branch or even restart your projects then you can persist it as a task
 
-![https://images.tango.us/public/screenshot_57812431-5034-451d-b6f6-9c41ee4a4d96.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.2041&fp-z=3.0619&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_57812431-5034-451d-b6f6-9c41ee4a4d96.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.2041&fp-z=3.0619&w=1200&ar=3892%3A3008)
+![When opening the devtools menu and selecting tasks, a submenu with your tasks and an option to add a new task is shown. The new task option is highlighted.](https://images.tango.us/public/screenshot_57812431-5034-451d-b6f6-9c41ee4a4d96.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.2041&fp-z=3.0619&w=1200&ar=3892%3A3008)
 
 ### 6. Just paste the command to the Command Palette and Projects will create a configuration file
 
-![https://images.tango.us/public/screenshot_3378f1fc-cc81-4028-ab1a-fb206716d182.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_3378f1fc-cc81-4028-ab1a-fb206716d182.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008)
+![The command palette is shown with an indicator that the current action is adding a task, and the command is pasted inside the input.](https://images.tango.us/public/screenshot_3378f1fc-cc81-4028-ab1a-fb206716d182.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008)
 
 ### 7. Put it in the right place in your configuration
 
@@ -45,4 +45,4 @@ If you define it as a task you will be able to run the container from the UI. Yo
 Tip: Commit your changes and add the configuration to your repository so Projects will be able to run the container for every newly created branch.
 </Callout>
 
-![https://images.tango.us/public/screenshot_d470cb2e-7005-4caa-bcb6-218c104eb298.png?crop=focalpoint&fit=crop&fp-x=0.3920&fp-y=0.5279&fp-z=1.0592&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_d470cb2e-7005-4caa-bcb6-218c104eb298.png?crop=focalpoint&fit=crop&fp-x=0.3920&fp-y=0.5279&fp-z=1.0592&w=1200&ar=3892%3A3008)
+![The tasks.json file is open in the editor and shows all tasks that exist for the project.](https://images.tango.us/public/screenshot_d470cb2e-7005-4caa-bcb6-218c104eb298.png?crop=focalpoint&fit=crop&fp-x=0.3920&fp-y=0.5279&fp-z=1.0592&w=1200&ar=3892%3A3008)

--- a/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
+++ b/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
@@ -27,7 +27,7 @@ In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that tak
 
 If you run a development server for example inside the container and it opens up a port then Projects will detect that automatically and make the preview available. You can open the preview from the Other Previews in this case.
 
-![Untitled](https://s3-us-west-2.amazonaws.com/secure.notion-static.com/3a225439-9c75-4f67-a1f6-5946a097e3d8/Untitled.png)
+![The devtools have an option with other previews. Selecting this option will shows a submenu with ports running the previews.](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F3a225439-9c75-4f67-a1f6-5946a097e3d8%2FUntitled.png?table=block&id=2c4272cf-8620-4bd5-a722-c5aaa5ddc2e4)
 
 ### 5. If you would like to start the given container every time you create a new branch or even restart your projects then you can persist it as a task
 


### PR DESCRIPTION
<details>
<summary><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/fragrant-surf?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/fragrant-surf">VS Code</a></summary>
<ul><li><a href="https://codesandbox.io/p/devtool/preview/0usopt?task=dev:projects&port=3001">Dev Projects</a></li><li><a href="https://codesandbox.io/p/devtool/preview/0usopt?task=dev:sandbox&port=3000">Dev Sandbox</a></li><li><a href="https://codesandbox.io/p/devtool/preview/0usopt?task=dev:vscode&port=3002">Dev VS code</a></li></ul>
</details>

<!-- open-in-codesandbox:complete -->


- [x] Add `alt` text to docker tutorial page images
- [x] Fix broken image for step four