### PR TITLE
chore: add a note for CodeSandbox CI for private repos

### DIFF
--- a/packages/sandbox-docs/pages/ci.md
+++ b/packages/sandbox-docs/pages/ci.md
@@ -43,7 +43,7 @@ your library by creating a file called `ci.json` in a folder called
 `.codesandbox` (`.codesandbox/ci.json`) in the root of your repo. An example PR
 can be found [here](https://github.com/facebook/react/pull/17175).
 
-**Note:** CodeSandbox CI only works in public repositories for now.
+**Note:** CodeSandbox CI only works in public repositories for now. Send us an e-mail to hello@codesandbox.io if you're interested to set this up for your private repositories.
 
 ## Configuration
 


### PR DESCRIPTION
<details>
<summary><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.light.svg#gh-dark-mode-only" /><img alt="CodeSandbox logo" src="https://raw.githubusercontent.com/codesandbox/open-in-codesandbox/main/assets/csb.svg#gh-light-mode-only" />&nbsp; Open in CodeSandbox <a href="https://codesandbox.io/p/github/codesandbox/docs/draft/pensive-ishizaka?workspace=%7B%22gitSidebarPanel%22:%22PR%22,%22sidebarPanel%22:%22GIT%22%7D">Web Editor</a> | <a href="https://codesandbox.io/p/vscode?owner=codesandbox&repo=docs&branch=draft/pensive-ishizaka">VS Code</a></summary>
<ul><li><a href="https://codesandbox.io/p/devtool/preview/8vhj0b?task=dev:projects&port=3001">Dev Projects</a></li><li><a href="https://codesandbox.io/p/devtool/preview/8vhj0b?task=dev:sandbox&port=3000">Dev Sandbox</a></li><li><a href="https://codesandbox.io/p/devtool/preview/8vhj0b?task=dev:vscode&port=3002">Dev VS code</a></li></ul>
</details>

<!-- open-in-codesandbox:complete -->


