### PR TITLE
Update GitHub App docs

### DIFF
--- a/packages/projects-docs/pages/learn/integrations/github-app.md
+++ b/packages/projects-docs/pages/learn/integrations/github-app.md
@@ -5,46 +5,103 @@ description: GitHub integration that adds CodeSandbox links in GitHub pull reque
 
 # GitHub App
 
+Integrating CodeSandbox and GitHub using our GitHub App allows you to streamline your development and review process.
 
-The integration of CodeSandbox and GitHub allows you to automatically add links to each PR description to facilitate the review process. 
+This [higher level of integration](#i-approved-a-github-oauth-app-when-i-created-my-codesandbox-account-why-do-i-need-another-github-integration) offers several benefits to your project:
 
+- Automatically add links to open your code in CodeSandbox or jump straight to a preview of the running code from any pull request
+- Add previews of the running code as **Deployments** in the GitHub UI, enabling access for reviewers and CI tools
+
+We're always looking for ways to make CodeSandbox a seamless part of your development workflow, and our GitHub App is the best way to take advantage.
+
+
+### Pull Request Links
+
+The integration of CodeSandbox and GitHub allows you to automatically add links to each pull request to facilitate the review process.
+{/* NOTE: Project settings not yet available in the client */}
+{/* This functionality can be enabled or disabled in your project settings. */}
 
 ![GitHub and CodeSandbox Integration](../images/GH-App-integration.jpg)
 
-
-
-#### Open Preview
-This link will start up a stand-alone devtool that spins up the preview link.
-
 #### Open in Web Editor
-This link opens the branch in the CodeSandbox Projects Web Editor. Because the branch is a shared environment, you will be able to see any running previews, tests or other DevTools that the PR author left open to assist with the review process.
+This link opens the branch in the CodeSandbox Projects Web Editor.
+Because the branch is a shared environment, you will be able to see any running previews, tests, or other DevTools that the PR author left open to assist with the review process.
 
 #### Open in VS Code Extension
-If VS Code is your preferred development environment, you can still open the branch directly from this link using [remote-ssh](https://code.visualstudio.com/docs/remote/ssh).
+If VS Code (or VS Code Insiders) is your preferred development environment, you can open the branch directly from this link using [remote-ssh](https://code.visualstudio.com/docs/remote/ssh).
+
+#### Open Preview(s)
+These links will take you directly to a preview environment — or a standalone devtool of a running preview task — depending on your task configuration.
+
+
+### Deployments
+
+For projects with preview tasks configured, CodeSandbox can add [Deployments](https://docs.github.com/en/repositories/viewing-activity-and-data-for-your-repository/viewing-deployment-activity-for-your-repository) to GitHub for easy access to running previews.
+These deployments provide easy access for individuals, as well as programmatic access for CI tasks using the [GitHub API](https://docs.github.com/en/rest/deployments).
+Look for entries like the following:
+
+```json
+{
+    // Deployment fields...
+    "environment": "CodeSandbox (Task Name)",
+    "payload": {
+        "provider": "CodeSandbox",
+        "codesandbox": {
+            "preview_url": "...",
+            "shortid": "...",
+            "task": "..."
+        }
+    }
+}
+```
+
+Don't worry if you have other services creating deployments for your project; CodeSandbox will only manage deployments with `"provider": "CodeSandbox"` in the payload.
+For more complicated projects, CodeSandbox will create one deployment for each task configured with a preview.
+
+{/* NOTE: Project settings not yet available in the client */}
+{/* This functionality is disabled by default, and can be enabled in your project settings. */}
 
 
 
-## Installing GitHub Apps
+## Installing the GitHub App
 
 ![Installing GitHub Apps](../images/GH-App-standalone.jpg)
-The installation of the GitHub App can only be done by **organization admins** or **repository owners**. However, it is possible to request that a GitHub App be installed in repositories where you don't have the necessary permissions. Organization owners and repository admins will be notified to approve or deny these requests.  
 
-After the installation request is made, the owner of the repository or an admin on the organization will be notified on GitHub and via email. 
+The GitHub App can be installed by...
 
-- Installation request that appears when importing a repo for the first time.
-- GitHub alls can be installed on an organization level or for individual repositories
+- An individual user, for some or all of the repositories owned by that user
+- An organization admin, for some or all of the repositories in that organization
+- A repository admin, for that specific repository
 
-Alternatively, you can also configure the app through it's official [GitHub App Page](https://github.com/apps/codesandbox)
+However, it is possible to request installation of a GitHub App in repositories where you don't have the necessary permissions.
+Organization owners and repository admins will receive a notification on GitHub and via email asking them to approve or deny the request.
+Alternatively, you can configure the App through its official [GitHub App Page](https://github.com/apps/codesandbox).
+
+
 
 ## Privacy and Permissions
+
 The GitHub App allows CodeSandbox to retrieve some information about your GitHub account and, in some circumstances, to make changes on GitHub on your behalf. 
 
-Users can select specific repositories or grant access to all repositories in an organization. This selection can be changed time through [GitHub Settings](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/authorizing-github-apps).
+Users can select specific repositories or grant access to all repositories in an organization.
+This selection can be changed at any time in the [GitHub Settings](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/authorizing-github-apps).
 
-For more information, check out the  [GitHub App documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/authorizing-github-apps)
+For more information, check out the [GitHub App documentation](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/authorizing-github-apps).
+
+
 
 ## FAQs
 
 #### I approved a GitHub OAuth App when I created my CodeSandbox account. Why do I need another GitHub integration?
 This GitHub App is different from the OAuth integration required by Sandboxes and Projects. The [OAuth integration](https://gitHub.com/settings/connections/applications/c07a89833b557afc7be2) allows CodeSandbox to import repositories from GitHub, while the GitHub App allows CodeSandbox to provide the features listed above.
 
+#### Why is the GitHub App asking for additional permissions after I've already installed it?
+
+Occasionally we need to modify the permissions of the GitHub App in order to support new features.
+GitHub requires users to approve the new permissions before they take effect.
+Following are some additional details about changes we've made:
+
+- **31 August 2022**: Added `deployments` permission in order to add a deployment to the GitHub UI for each preview task.
+This feature will only be active if (1) branch deployments are enabled for the project, and (2) task previews are configured in `.codesandbox/tasks.json`.
+
+You can review the App's permissions at any time by choosing **Configure** from the official [GitHub App Page](https://github.com/apps/codesandbox).


### PR DESCRIPTION
This PR adds information about our new Deployments integration to the GitHub App docs. It also does some minor copy editing throughout the page.