### PR TITLE
fix: make link with hashtag absolute

### DIFF
--- a/packages/projects-docs/pages/learn/integrations/github-app.mdx
+++ b/packages/projects-docs/pages/learn/integrations/github-app.mdx
@@ -61,7 +61,7 @@ Look for entries like the following:
 Don't worry if you have other services creating deployments for your project; CodeSandbox will only manage deployments with `"provider": "CodeSandbox"` in the payload.
 For more complicated projects, CodeSandbox will create one deployment for each task configured with a preview.
 
-Make sure to [configure the `preview` field](/learn/setting-up/tasks#preview-field) in your tasks for them to show up in the deployments.
+Make sure to [configure the `preview` field](/docs/projects/learn/setting-up/tasks#preview-field) in your tasks for them to show up in the deployments.
 
 {/* NOTE: Project settings not yet available in the client. */}
 {/* This functionality is disabled by default, and can be enabled in your project settings. */}


### PR DESCRIPTION
It looks like URLs with a `#` are not rewritten correctly. Quickly fixing this with this change, we should take a look at this.