### PR TITLE
fix: update broken relative links

### DIFF
--- a/packages/projects-docs/pages/faq.md
+++ b/packages/projects-docs/pages/faq.md
@@ -67,7 +67,7 @@ re-order those items by dragging them in that bar. Whichever is 1st from left to
 right in the list of tabs is what opens first when other folks view the sandbox.
 The ordering is maintained within the sandbox. You can also achieve this change
 by setting a value for "view" in a
-[sandbox config file](/docs/configuration#sandbox-configuration).
+[sandbox config file](/configuration#sandbox-configuration).
 
 ## How do I change the font used in the editor?
 

--- a/packages/projects-docs/pages/learn/introduction/workspace.md
+++ b/packages/projects-docs/pages/learn/introduction/workspace.md
@@ -40,4 +40,4 @@ and only the original creator of the sandbox can delete it.
 
 You and other members can open a sandbox at the same time and see each other's
 cursor to work together. You can still invite other people who aren't members of
-the team to the sandbox or [live session](/docs/live).
+the team to the sandbox or [live session](/learn/getting-started/collaborate-share).

--- a/packages/projects-docs/pages/learn/repositories/editors.md
+++ b/packages/projects-docs/pages/learn/repositories/editors.md
@@ -143,7 +143,7 @@ Changes that are made to a file are reflected in the editor of every user. Selec
 <br/>
 ## Reviewing PRs in VSCode
 
-You can review PRs directly from VSCode while connected to CodeSandbox. To do this, you should install the [GitHub App of CodeSandbox](/docs/integrations/github-app). With this app, every PR will have a link to open the branch in VSCode.
+You can review PRs directly from VSCode while connected to CodeSandbox. To do this, you should install the [GitHub App of CodeSandbox](/learn/integrations/github-app). With this app, every PR will have a link to open the branch in VSCode.
 
 We also recommend to install the [GitHub Pull Request](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, and configure it as a default extension in your user settings (as outlined [here](#default-user-extensions)). With this extension you can put comments on GitHub directly from your editor.
 

--- a/packages/projects-docs/pages/learn/sandboxes/tests.md
+++ b/packages/projects-docs/pages/learn/sandboxes/tests.md
@@ -20,12 +20,12 @@ not possible in the Client Sandbox experience.
 <br/>
 ## How to write tests in the CodeSandbox Browser Sandboxes
 
-In [Client sandboxes](/docs/environment) you can run Jest tests by creating
+In [Browser sandboxes](/learn/sandboxes/editors) you can run Jest tests by creating
 files that end with `.test.js`, `.spec.js`, `.test.ts(x)` and `.spec.js(x)`. We
 will automatically detect these test files and show the results in the Tests
 tab.
 
-Note: In [Container sandboxes](/docs/environment) you can still use Jest (or
+Note: In Container sandboxes you can still use Jest (or
 whichever test framework you want), but we don't auto-detect these and you'd
 need to set it up yourself as you would locally.
 


### PR DESCRIPTION
Some links were resulting in 404 pages:

- [x] "sandbox config file" link on faq page
- [x] "live session link" on workspace page
- [x] "GitHub App" link on editors page 
- [x] "Client Sandboxes" on tests page
- [x] "Container Sandboxes" on tests page