### PR TITLE
Several copy updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repository is hosting all product documentation pages of CodeSandbox.
 - iOS Documentation
 - CodeSandbox Documentation
 - CodeSandbox Projects Documentation
-- VScode Documentation
+- VS Code Documentation
 
 ## About this repository
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is hosting all product documentation pages of CodeSandbox.
 
 ## About this repository
 
-The Projects is leveraging [Nextra](https://nextra.vercel.app/), which explains a lot of how the individual projects run. So we recommend checking it out to get a good understanding of the structure of this repository.
+The Projects is leveraging [Nextra](https://nextra.vercel.app/), which explains a lot of how the individual projects run. So we recommend checking it out to get a good understanding of the strSucture of this repository.
 
 The individual documentations can be found in the
 - `packages`

--- a/packages/projects-docs/pages/faq.md
+++ b/packages/projects-docs/pages/faq.md
@@ -165,7 +165,7 @@ For questions and support please use the community [discord server](https://disc
        ## Sandboxes
 
 ### I'm getting a Git error resolving a dependency. Why is that?
-CodeSandbox for iOS is only compatible with dependencies hosted and accessible via HTTP or HTTPS. This is because the app doesn't provide local shell environments where you can run arbitrary commands, like git. Use CodeSandbox Projects instead.
+CodeSandbox for iOS is only compatible with dependencies hosted and accessible via HTTP or HTTPS. This is because the app doesn't provide local shell environments where you can run arbitrary commands, like git. Use the [CodeSandbox web editor](/learn/sandboxes/editors) instead.
 
 You may find some of the following answers helpful if you have gone through the sections in this documentation but you still haven’t cleared your doubts:
     
@@ -185,7 +185,7 @@ The runtime provides a `WEB_PORT` environment variable matching the port used by
 This is because iOS suspends the process while the application is in background and with it all its activity.
 
 ### My sandbox requires Node.js 14 but the app uses Node.js 12. How can I change the Node.js version?
-The application uses a Node.js port that hasn’t been upgraded to Node.js 14 as we have been focused on integrating CodeSandbox Projects instead. We will be making changes in this front so please stay tuned.
+The application uses a Node.js port that hasn’t been upgraded to Node.js 14 as we have been focused on integrating the new CodeSandbox experience instead. We will be making changes in this front, so please stay tuned.
 
 ## Repositories
 

--- a/packages/projects-docs/pages/faq.md
+++ b/packages/projects-docs/pages/faq.md
@@ -155,7 +155,7 @@ It is possible to work in an “un-synced” state. In order for CodeSandbox fea
 
 ## Who can access my code?
 
-Only people on your CodeSandbox team with permissions to the repository may join as a collaborator. Repository permissions are carried over from Github. To add someone new to the team, provide access on Github and add them to the CodeSandbox. From there, they can access the code in the browser or follow the steps above to use VS Code.
+Only people on your CodeSandbox team with permissions to the repository may join as a collaborator. Repository permissions are carried over from GitHub. To add someone new to the team, provide access on GitHub and add them to the CodeSandbox. From there, they can access the code in the browser or follow the steps above to use VS Code.
 
 ## More Questions?
 

--- a/packages/projects-docs/pages/learn/getting-started/your-first-repository.md
+++ b/packages/projects-docs/pages/learn/getting-started/your-first-repository.md
@@ -20,9 +20,9 @@ Start working on a Repository by importing an existing repository from GitHub or
 
 1. Go to the **[Dashboard](https://codesandbox.io/dashboard)**.
 
-2. From the left sidebar, click on the **team** (personal or another) you want to import your project into. New teams can be created from the same menu.
+2. From the left sidebar, click on the **team** (personal or another) you want to import your project into. You can create new teams right from this menu.
   
-3. Click on the **`New`** button. In the top right corner.
+3. Click on the **`Create`** button, in the top right corner.
 
 4. Select **`Import from GitHub`**
     
@@ -34,7 +34,7 @@ For valid GitHub URLs, follow this format:
 **`https://` `github.com/` `:org/` `:repo`**
 - Include the protocol, such as `https`;
 - Don't include branch name;
-- for example `https://github.com/facebook/react`.
+- For example, `https://github.com/facebook/react`.
 </Callout>
 
 - If the search does not return any matches, click on the **`Show all`** button under the last repository visible in the list to load more repositories.
@@ -51,13 +51,13 @@ For valid GitHub URLs, follow this format:
 - Verify your team's permission to open CodeSandbox Repositories.
 
 - Verify your **repository permissions on GitHub**. 
-You need to have `write` permission on Github to be able to import the project. Repositories where you only have `read` access can only be forked.
+You need to have `write` permission on GitHub to be able to import the project. Repositories where you only have `read` access can only be forked.
 
 - Verify your **GitHub permissions**. 
-CodeSandbox Projects requires full git access to be able to import and commit. If you face any  authentication errors, follow the steps to reset your github permissions listed below.
+CodeSandbox requires full git access to be able to import and commit. If you face any authentication errors, follow the steps to reset your GitHub permissions listed below.
     
     
-#### **Resetting Github permissions**
+#### **Resetting GitHub permissions**
 
 1. Go to the **[Dashboard](https://codesandbox.io/dashboard)**.
 
@@ -69,11 +69,11 @@ CodeSandbox Projects requires full git access to be able to import and commit. I
   
 4. Go to **Integrations**. 
 
-5. **Sign out from GitHub and sign in again** to reconnect your GitHub Account. 
+5. **Sign out from GitHub and sign in again** to reconnect your GitHub account. 
   
 #### **Invalid authorization code on Firefox and Safari**
     
-Safari and Firefox block popups by default. Please make sure you give the domain permission (through browser settings) or refresh the page after you opened the popup and try again.
+Safari and Firefox block popups by default. Please make sure you give the domain permission (through the browser settings) or refresh the page after you opened the popup and try again.
     </WrapContent>
     <WrapContent>
 
@@ -82,20 +82,20 @@ Safari and Firefox block popups by default. Please make sure you give the domain
 1. If needed, install [Visual Studio Code](https://code.visualstudio.com/) for Windows *(7+)*, macOS *(10.11 +)*, or Linux.
 2. Download and install the [CodeSandbox extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) for Visual Studio Code.
 3. Wait for the extension to finish downloading and then reload VS Code when prompted.
-4. Click on CodeSandbox icon in the side menu and login 
-5. Connect to your project
+4. Click on CodeSandbox icon in the side menu and login.
+5. Connect to your project.
 
 <br/>
 ## How it works
 
-When you connect to your CodeSandbox account and open a branch, a virtual container is spun up with [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) to allow you to access your code. At the same time, a connection is established with a CodeSandbox API called Pitcher. This is the service that powers all of the collaboration features across different editors including the web and mobile. 
+When you connect to your CodeSandbox account and open a branch, a virtual container is spun up with [Remote - SSH](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-ssh) to allow you to access your code. At the same time, a connection is established with a CodeSandbox API called Pitcher. This is the service that powers all of the collaboration features across different editors, including the web and mobile editors. 
 
-It is possible to work on the ssh connection while disconnected to Pitcher, but you should be mindful that other team members may be making changes to your branch while you are in an un-synced state, so be sure to commit often.
+It is possible to work on the SSH connection while disconnected from Pitcher, but you should be mindful that other team members may be making changes to your branch while you are in an un-synced state, so be sure to commit often.
 
 Only people on your team in CodeSandbox have access to these repositories. 
 
-So the VSCode Extension actually connects directly to the container with an SSH connection, completely bypassing Pitcher, where it operates directly with the FileSystem.
-On top of this we also connect to Pitcher, just like we do in the browser, where we "tie it together".
+So the VS Code extension actually connects directly to the container with an SSH connection, completely bypassing Pitcher, where it operates directly with the FileSystem.
+On top of this, we also connect to Pitcher, just like we do in the browser, where we "tie it together".
 
 <br/>
 <br/>
@@ -125,19 +125,19 @@ Once you open the branch, follow these steps:
 <br/>
 ### Preferences
 
-CodeSandbox Projects will remember your choice of the IDE and will use it as the default button action next time you wish to open your project in Visual Studio Code.
+CodeSandbox will remember your choice of the IDE and will use it as the default button action next time you wish to open your project in Visual Studio Code.
 
 You can reset your choice at any time by selecting a different option from the "Open in VS Code" dropdown menu.
     </WrapContent>
      <WrapContent>
 ## Getting Started
 
-You can start using CodeSandbox Projects from the web, VSCode, or even iOS so choosing the most convenient platform that fits to your workflow. Furthermore, whenever you want just hop between different clients and continue the work on your project where you left off.
+You can start using CodeSandbox from the web, VS Code, or even iOS - so you can choose the [most convenient platform](/learn/sandboxes/editors) that fits your workflow. Furthermore, you can easily switch between different clients whenever you want and continue the work on your project where you left off.
 
 <br/>
 ## Importing a project
 
-Once you have signed into CodeSandbox with your GitHub account you can import your first project. 
+Once you have signed into CodeSandbox with your GitHub account, you can import your first project. 
 
 You can easily import any public repositories by pasting its GitHub URL into the “GitHub repository URL” field and hitting the “enter” key or the “Import button”. This action will automatically fork the repository and spin a development environment for you to start coding straight away.
 
@@ -146,8 +146,3 @@ In addition, you can create a project from any repository (public or private if 
 ![IMG_01E76C8C3559-1.jpg](../images/IMG_01E76C8C3559-1.jpg)
     </WrapContent>
 </Tabs>
-    
-
-
-    
-    

--- a/packages/projects-docs/pages/learn/integrations/github-app.mdx
+++ b/packages/projects-docs/pages/learn/integrations/github-app.mdx
@@ -26,7 +26,7 @@ The integration of CodeSandbox and GitHub allows you to automatically add links 
 
 #### Open in Web Editor
 
-This link opens the branch in the CodeSandbox Projects Web Editor.
+This link opens the branch in the CodeSandbox web editor.
 Because the branch is a shared environment, you will be able to see any running previews, tests, or other DevTools that the PR author left open to assist with the review process.
 
 #### Open in VS Code Extension
@@ -76,7 +76,7 @@ The GitHub App can be installed by...
 - An organization admin, for some or all of the repositories in that organization
 - A repository admin, for that specific repository
 
-However, it is possible to request installation of a GitHub App in repositories where you don't have the necessary permissions.
+However, it is possible to request the installation of a GitHub App in repositories where you don't have the necessary permissions.
 Organization owners and repository admins will receive a notification on GitHub and via email asking them to approve or deny the request.
 Alternatively, you can configure the App through its official [GitHub App Page](https://github.com/apps/codesandbox).
 
@@ -93,7 +93,7 @@ For more information, check out the [GitHub App documentation](https://docs.gith
 
 #### I approved a GitHub OAuth App when I created my CodeSandbox account. Why do I need another GitHub integration?
 
-This GitHub App is different from the OAuth integration required by Sandboxes and Projects. The [OAuth integration](https://gitHub.com/settings/connections/applications/c07a89833b557afc7be2) allows CodeSandbox to import repositories from GitHub, while the GitHub App allows CodeSandbox to provide the features listed above.
+This GitHub App is different from the OAuth integration required by Sandboxes and Repositories. The [OAuth integration](https://gitHub.com/settings/connections/applications/c07a89833b557afc7be2) allows CodeSandbox to import repositories from GitHub, while the GitHub App allows CodeSandbox to provide the features listed above.
 
 #### Why is the GitHub App asking for additional permissions after I've already installed it?
 

--- a/packages/projects-docs/pages/learn/introduction/overview.md
+++ b/packages/projects-docs/pages/learn/introduction/overview.md
@@ -34,17 +34,17 @@ CodeSandbox provides many alternatives for you to code. Each option is built to 
 <WrapContent>
 ## Keep working on VS Code
 
-**Install the CodeSandbox Projects VS Code extension and open any branch directly in your VSCode editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
+**Install the CodeSandbox Projects VS Code extension and open any branch directly in your VS Code editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
 
 <div className="ctaContainer">
-    <ButtonDoc title={<>Get the <br/>VSCode Extension</>} cta="Install" description="" link="https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects" />
+    <ButtonDoc title={<>Get the <br/>VS Code Extension</>} cta="Install" description="" link="https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects" />
 </div>
 
-## Opening a branch in VSCode
+## Opening a branch in VS Code
 
 ![Open in vscode button](../images/getting-openvscode.jpg)
 
-To start working in a branch on VSCode, open the branch in the Editor and click on the `Open in VSCode` button positioned in the bottom left corner. This will prompt you to install the CodeSandbox extension  responsible for making the connection to our cloud development environment.
+To start working in a branch on VS Code, open the branch in the Editor and click on the `Open in VS Code` button positioned in the bottom left corner. This will prompt you to install the CodeSandbox extension  responsible for making the connection to our cloud development environment.
 
 ### Learn more
 

--- a/packages/projects-docs/pages/learn/introduction/overview.md
+++ b/packages/projects-docs/pages/learn/introduction/overview.md
@@ -34,7 +34,7 @@ CodeSandbox provides many alternatives for you to code. Each option is built to 
 <WrapContent>
 ## Keep working on VS Code
 
-**Install the Projects VSCode extension and open any branch directly in your VSCode editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
+**Install the CodeSandbox Projects VS Code extension and open any branch directly in your VSCode editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
 
 <div className="ctaContainer">
     <ButtonDoc title={<>Get the <br/>VSCode Extension</>} cta="Install" description="" link="https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects" />

--- a/packages/projects-docs/pages/learn/repositories/commandpalette.md
+++ b/packages/projects-docs/pages/learn/repositories/commandpalette.md
@@ -1,6 +1,6 @@
 ---
 title: Command Palette
-description: With the command palette, the CodeSandbox Projects functionality is almost completely accessible from your keyboard
+description: With the command palette, you can access nearly all the functionalities of CodeSandbox from your keyboard.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
@@ -8,9 +8,9 @@ import Video from '../../../../../shared-components/Video'
 
 # Command Palette
 
-![CodeSandbox Projects Command Palette](../images/command-cover.jpg)
+![CodeSandbox Command Palette](../images/command-cover.jpg)
 
-The functionalities of CodeSandbox Projects are almost completely accessible from your keyboard as well. Bring up the Command Palette on the Dashboard or in the editor using <kbd>⌘</kbd> + <kbd>K</kbd> and type away.
+You can access nearly all the functionalities of CodeSandbox from your keyboard. Bring up the Command Palette on the Dashboard or in the editor using <kbd>⌘</kbd> + <kbd>K</kbd> and type away.
 
 With the Command Palette, you can:
 - Search files by path
@@ -20,13 +20,13 @@ With the Command Palette, you can:
 - Run git operations
 - Switch branches or create new ones
 
-You can also run commands in the terminal directly from the Command Palette. Just type the command and Projects will open a terminal and execute it.
+You can also run commands in the terminal directly from the Command Palette. Just type the command and CodeSandbox Repositories will open a terminal and execute it.
 
 <Video src="../../command-runscript.mp4" />
 
 
-If you use the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects), Projects related functionality is also available in VS Code’s command palette (<kbd>⇧</kbd> <kbd>⌘</kbd> <kbd>P</kbd>).
+If you use the [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects), CodeSandbox functionality is also available in VS Code’s command palette (<kbd>⇧</kbd> <kbd>⌘</kbd> <kbd>P</kbd>).
 
-![CodeSandbox Projects Command Palette](../images/command-vscode.jpg)
+![CodeSandbox Command Palette](../images/command-vscode.jpg)
 
-Keyboard shortcuts are also supported for the most common operations. For the full list, go to the [Keyboard Shortcuts](./shortcuts) page.
+Keyboard shortcuts are also supported for the most common operations. For the complete list, go to the [Keyboard Shortcuts](./shortcuts) page.

--- a/packages/projects-docs/pages/learn/repositories/devtools.md
+++ b/packages/projects-docs/pages/learn/repositories/devtools.md
@@ -7,7 +7,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # DevTools
  
-![CodeSandbox Projects Preview](../images/devtools-open.jpg)
+![CodeSandbox Preview](../images/devtools-open.jpg)
 
 Devtools are tools for developers to work faster and more efficiently. They are useful for debugging, testing, and developing. They are collaborative by default, allowing you to share their content: a terminal output, a preview error, a console log...
 
@@ -16,24 +16,24 @@ Add as many devtools as you want. For one or two devtools, the layout will adapt
 
 ## Start a Devtool
 
-You can add a Devtool by clicking in the `+` button on the header or by pressing <kbd>Cmd/Clt</kbd> <kbd>shift</kbd> <kbd>o</kbd> to open the DevTool menu.
+You can add a Devtool by clicking on the `+` button on the header or by pressing <kbd>Cmd/Clt</kbd> <kbd>shift</kbd> <kbd>o</kbd> to open the DevTool menu.
 
 
 
 ## Manage your DevTool 
 
-![CodeSandbox Projects Preview](../images/devtools-options.jpg)
+![CodeSandbox Preview](../images/devtools-options.jpg)
 
 #### Minimize
 
-Minimize the Devtool by clicking in the `...` icon in the top left corner and selecting the option `Minimize`. A minimized view is useful when you have limited viewport space and would like to still track some processes. 
+Minimize the Devtool by clicking on the `...` icon in the top left corner and selecting the option `Minimize`. A minimized view is useful when you have limited viewport space and would like to still track some processes. 
 
 #### Close 
 
-Close the Devtool by clicking in the `...` in the top left corner and selecting the option `Close`. You can also close all devtools through the command pallete (<kbd>Cmd/Clt</kbd> <kbd>K</kbd>) and typing `close all devtools`.
+Close the Devtool by clicking on the `...` in the top left corner and selecting the option `Close`. You can also close all devtools through the command palette (<kbd>Cmd/Clt</kbd> <kbd>K</kbd>) by typing `close all devtools`.
 
 <Callout emoji="→">
-Closing a devtool will not stop it, it will keep running in the background. If you want to stop the process, you must select option `Close and stop`. 
+Closing a devtool will not stop it, it will keep running in the background. If you want to stop the process, you must select the option `Close and stop`. 
 </Callout>
 
 #### Reorder
@@ -55,7 +55,7 @@ Setting up the Devtools makes it easier for non-developers to access and run you
 - **[Task](./task)**
 - **[Terminal](./terminal)**
 
-We are working on supporting others DevTools in the future, which may include:
+We are working on supporting other DevTools in the future, which may include:
 
 - Test runner UI
 - Viewing / editing [Design Tokens](https://css-tricks.com/what-are-design-tokens/) in a project

--- a/packages/projects-docs/pages/learn/repositories/editors.md
+++ b/packages/projects-docs/pages/learn/repositories/editors.md
@@ -187,7 +187,7 @@ It is possible to work in an “un-synced” state. In order for CodeSandbox fea
 
 ### Who can access my code?
 
-Only people on your CodeSandbox team with permissions to the repository may join as a collaborator. Repository permissions are carried over from Github. To add someone new to the team, provide access on Github and add them to the CodeSandbox. From there, they can access the code in the browser or follow the steps above to use VS Code.
+Only people on your CodeSandbox team with permissions to the repository may join as a collaborator. Repository permissions are carried over from GitHub. To add someone new to the team, provide access on GitHub and add them to the CodeSandbox. From there, they can access the code in the browser or follow the steps above to use VS Code.
 
 ### More Questions?
 

--- a/packages/projects-docs/pages/learn/repositories/editors.md
+++ b/packages/projects-docs/pages/learn/repositories/editors.md
@@ -71,7 +71,7 @@ The code editor is where the magic happens ✨. We provide a base experience for
 - Multiple Editors
 - Diff view
 
- If you want more advanced features, you can download our [VSCode extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the Repository inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
+ If you want more advanced features, you can download our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the Repository inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
 
 ### DevTool
 
@@ -93,7 +93,7 @@ Press <kbd>Cmd/Ctrl</kbd> <kbd>.</kbd> to hide the DevTools.
     </WrapContent>
     <WrapContent>
        ![](../images/cover-vscode.jpg)
-       Open any branch directly in your local VSCode and use all the extensions and keybindings that you’ve already configured. On top of this, all editors can collaborate seamlessly, so your team members can follow your steps on VSCode without leaving the Web Editor.
+       Open any branch directly in your local VS Code and use all the extensions and keybindings that you’ve already configured. On top of this, all editors can collaborate seamlessly, so your team members can follow your steps on VS Code without leaving the Web Editor.
        
 <br/>
        ## Open your branch in VS Code
@@ -141,9 +141,9 @@ Changes that are made to a file are reflected in the editor of every user. Selec
 
 <Video src="../../vscode-following.mp4" />
 <br/>
-## Reviewing PRs in VSCode
+## Reviewing PRs in VS Code
 
-You can review PRs directly from VSCode while connected to CodeSandbox. To do this, you should install the [GitHub App of CodeSandbox](/learn/integrations/github-app). With this app, every PR will have a link to open the branch in VSCode.
+You can review PRs directly from VS Code while connected to CodeSandbox. To do this, you should install the [GitHub App of CodeSandbox](/learn/integrations/github-app). With this app, every PR will have a link to open the branch in VS Code.
 
 We also recommend to install the [GitHub Pull Request](https://marketplace.visualstudio.com/items?itemName=GitHub.vscode-pull-request-github) extension, and configure it as a default extension in your user settings (as outlined [here](#default-user-extensions)). With this extension you can put comments on GitHub directly from your editor.
 
@@ -160,17 +160,17 @@ You can create the file `.vscode/extensions.json` in your repository to define t
 }
 ```
 
-This will make sure that Prettier and ESLint are installed whenever someone opens the branch in VSCode.
+This will make sure that Prettier and ESLint are installed whenever someone opens the branch in VS Code.
 
 ### Default User Extensions
 
-In case you have any personal extensions that you want to have in every branch, you can define those in your VSCode settings under the setting id `remote.SSH.defaultExtensions`. To change this setting, you can open VSCode settings (`CMD/Ctrl + ,`) and search for `remote.SSH.defaultExtensions`.
+In case you have any personal extensions that you want to have in every branch, you can define those in your VS Code settings under the setting id `remote.SSH.defaultExtensions`. To change this setting, you can open VS Code settings (`CMD/Ctrl + ,`) and search for `remote.SSH.defaultExtensions`.
 
-You can copy your favourite VSCode extension ids, and put them in that setting. From then on, these extensions will be automatically installed in your branches.
+You can copy your favourite VS Code extension ids, and put them in that setting. From then on, these extensions will be automatically installed in your branches.
 
-### VSCode Setting Sync
+### VS Code Setting Sync
 
-To sync your settings and keybindings between branches, you can enable VSCode Setting Sync. To learn more about how to set this up, you can check [here](https://code.visualstudio.com/docs/editor/settings-sync).
+To sync your settings and keybindings between branches, you can enable VS Code Setting Sync. To learn more about how to set this up, you can check [here](https://code.visualstudio.com/docs/editor/settings-sync).
 
 <br/>
 ## FAQs

--- a/packages/projects-docs/pages/learn/repositories/env.md
+++ b/packages/projects-docs/pages/learn/repositories/env.md
@@ -1,6 +1,6 @@
 ---
 title: Environment
-description: Configure your environment in CodeSandbox Projects
+description: Configure your environment in CodeSandbox.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
@@ -17,7 +17,7 @@ Based on our analysis of usual resource needs, we have defined these resources a
 | Memory  | 4Gi    |
 | Storage | 8Gi    |
 
-But we can go higher, up to 12vCPUs, 16Gi memory and 30Gi storage. If you hit any limitations while using Projects Beta, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limitations to suit your project.
+But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. If you hit any limitations while using CodeSandbox, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
 
 ## Persistence
 
@@ -48,7 +48,7 @@ Configure various aspects of the running VMs with the environment file. Currentl
 #### NodeJS
 
 <Callout emoji="⭑">
-If you already have a `.nvmrc` file containing a node version number in your project's root folder it will automatically be picked up by CodeSandbox Projects.
+If you already have a `.nvmrc` file containing a Node version number in your project's root folder it will automatically be picked up by CodeSandbox.
 </Callout>
 
 The environment file allows you to specify:
@@ -65,10 +65,10 @@ Single value configuration, type `string`, by default it is set to `"16"` .
 
 ## Docker support
 
-CodeSandbox Projects supports running docker containers inside any workspace. Run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a docker-compose file in your root folder, simply run `docker-compose up` and all your services will run within Projects.
+CodeSandbox supports running Docker containers inside any workspace. Run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a docker-compose file in your root folder, simply run `docker-compose up` and all your services will run within CodeSandbox.
 
 <Callout emoji="⭑">
-For a step-by-step guide, check out our tutorial [Getting started with Docker](https://codesandbox.io/docs/projects/tutorial/getting-started-with-docker)
+For a step-by-step guide, check out our tutorial [Getting started with Docker](/tutorial/getting-started-with-docker)
 </Callout>
 
 ## Nix support

--- a/packages/projects-docs/pages/learn/repositories/interactive-readme.md
+++ b/packages/projects-docs/pages/learn/repositories/interactive-readme.md
@@ -1,22 +1,22 @@
 ---
 title: Interactive Readme
-description: Create an interactive readme with CodeSandbox Project
+description: Create an interactive readme with CodeSandbox.
 ---
 
 # Interactive Readme
 
-Projects supports running [tasks](../setting-up/tasks) directly from Markdown. 
+CodeSandbox supports running [tasks](../setting-up/tasks) directly from Markdown. 
 
-![CodeSandbox Projects Preview](../images/interactive-readme-config.jpg)
+![CodeSandbox Preview](../images/interactive-readme-config.jpg)
 
 To configure the interactive Readme:
 1. Define a task using the [configuration file](../setting-up/tasks). Use the same shell command used in the `tasks.json` file in the markdown code block.
 
-![CodeSandbox Projects Code](../images/interactive-readme-syntax.jpg)
+![CodeSandbox Code](../images/interactive-readme-syntax.jpg)
 
-2. If there is a match, Projects will render a play icon next to the command in the interactive view. 
+2. If there is a match, CodeSandbox will render a play icon next to the command in the interactive view. 
 
-![CodeSandbox Projects Play](../images/interactive-readme-play.jpg)
+![CodeSandbox Play](../images/interactive-readme-play.jpg)
 
-Interactive tasks can be run by any user with read access to your project. 
+Interactive tasks can be run by any user with read access to your project.
 

--- a/packages/projects-docs/pages/learn/repositories/limitations.md
+++ b/packages/projects-docs/pages/learn/repositories/limitations.md
@@ -1,6 +1,6 @@
 ---
 title: Limitations
-description: Current limitations in CodeSandbox Projects
+description: Current limitations of Repositories in CodeSandbox.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
@@ -9,7 +9,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 ## sudo access
 
-Typically sudo access allows users to run programs with the privileges of another user, by default, the superuser. Currently, due to security reasons CodeSandbox projects doesn't provide an option to run sudo commands. This is necessary to provide you collaboration features on the top of the ephemeral developer environment experience.
+Typically, sudo access allows users to run programs with the privileges of another user - by default, the superuser. Currently, due to security reasons, CodeSandbox repositories don't provide an option to run sudo commands. This is necessary to provide you with collaboration features on top of the ephemeral developer environment experience.
 
 ### Workarounds
 
@@ -19,7 +19,7 @@ To work around this, there are two ways to install packages.
 
 CodeSandbox natively supports the [Nix](https://nixos.org/) package manager. To install a package, you can define a file in the root of your project called `csb.nix` and configure which packages should be automatically installed from the [nix package store](https://search.nixos.org/packages).
 
-An example configuration is this:
+See an example configuration below:
 
 ```nix
 with import <nixpkgs> {};
@@ -40,4 +40,4 @@ This automatically installs Postgres and `htop` the next time you open a termina
 
 #### Docker
 
-We also support running Docker. You can run `docker` directly from the terminal, and within the Docker containers you **do** have root access.
+We also support running Docker. You can run `docker` directly from the terminal, and within the Docker containers to which you **do** have root access.

--- a/packages/projects-docs/pages/learn/repositories/limitations.md
+++ b/packages/projects-docs/pages/learn/repositories/limitations.md
@@ -9,7 +9,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 ## sudo access
 
-Typically, sudo access allows users to run programs with the privileges of another user - by default, the superuser. Currently, due to security reasons, CodeSandbox repositories don't provide an option to run sudo commands. This is necessary to provide you with collaboration features on top of the ephemeral developer environment experience.
+Typically, sudo access allows users to run programs with the privileges of another user (the superuser) by default. Currently, due to security reasons, CodeSandbox Repositories don't provide an option to run sudo commands. This is necessary to provide you with collaboration features on top of the ephemeral developer environment experience.
 
 ### Workarounds
 

--- a/packages/projects-docs/pages/learn/repositories/overview.md
+++ b/packages/projects-docs/pages/learn/repositories/overview.md
@@ -32,9 +32,9 @@ Repositories are run on containers. When you press `Branch`, we automatically cr
 If you are looking at someone’s PR and want to quickly test a suggestion, simply click `Branch`, write the code and share a link to your changes. If you’re happy with the changes, merge that
 into the existing PR. All of this in under a minute.
 
-## Works with VSCode
+## Works with VS Code
 
-Open any branch directly in your local VSCode and use all the extensions and keybindings that you’ve already configured. On top of this, all editors can collaborate seamlessly, so your team members can follow your steps on VSCode without leaving the Web Editor.
+Open any branch directly in your local VS Code and use all the extensions and keybindings that you’ve already configured. On top of this, all editors can collaborate seamlessly, so your team members can follow your steps on VS Code without leaving the Web Editor.
 
 <Video src="../../introduction-vscode.mp4" />
 

--- a/packages/projects-docs/pages/learn/repositories/preview.md
+++ b/packages/projects-docs/pages/learn/repositories/preview.md
@@ -5,18 +5,18 @@ description:
 
 # Preview
 
-![CodeSandbox Projects Preview](../images/devtools-cover-preview.jpg)
+![CodeSandbox Preview](../images/devtools-cover-preview.jpg)
 
-When a running task opens a server on a port, that port will be attached to the task, turning it into a Preview type DevTool. Previews appear at the beginning of the list when you toggle the DevTools dropdown. 
+When a running task that opens a server on a port, that port will be attached to the task, turning it into a Preview-type DevTool. Previews appear at the beginning of the list when you toggle the DevTools dropdown. 
 
-## How do they work
+## How do Previews work?
 
 ### WebSocket Override
 
-We’ve patched WebSocket to ensure that always the right URL is accessed when opening a websocket. In the case that you try to access [`http://localhost:3000`](http://localhost:3000) using a websocket, we’ll rewrite it to `https://3000-:id.preview.csb.app` so the socket automatically connects to the right url.
+We’ve patched WebSocket to ensure that the right URL is always accessed when opening a websocket. In case you try to access [`http://localhost:3000`](http://localhost:3000) using a websocket, we’ll rewrite it to `https://3000-:id.preview.csb.app` so the socket automatically connects to the right URL.
 
 This will often make hot module reloading work out of the box for frameworks like Vite.
 
 ### Service Worker Proxy
 
-If possible, we try to install a service worker in the preview that will proxy requests to [`localhost:3000`](http://localhost:3000) to the corresponding dev url. The service worker only proxies URLs that are going to localhost, or URLs that go to e.g. `https://3000-:id.preview.csb.app:4000`.
+If possible, we try to install a service worker in the preview that will proxy requests to [`localhost:3000`](http://localhost:3000) to the corresponding dev URL. The service worker only proxies URLs that are going to localhost, or URLs that go to e.g. `https://3000-:id.preview.csb.app:4000`.

--- a/packages/projects-docs/pages/learn/repositories/secrets.md
+++ b/packages/projects-docs/pages/learn/repositories/secrets.md
@@ -1,6 +1,6 @@
 ---
 title: Environment variables and secrets
-description: Use configuration values and secrets in CodeSandbox Projects
+description: Use configuration values and secrets in CodeSandbox
 ---
 
 import Callout from 'nextra-theme-docs/callout'
@@ -8,17 +8,17 @@ import Video from '../../../../../shared-components/Video'
 
 # Environment variables and secrets
 
-Configure environment variables and secrets in your project, such as settings for your project or access tokens for APIs.
+You can configure environment variables and secrets in your project, such as settings for your project or access tokens for APIs.
 
-![CodeSandbox Projects Environment Variables](../images/env-var.jpg)
+![CodeSandbox Environment Variables](../images/env-var.jpg)
 
 ### Project-level environment variables and secrets
 
-Currently CodeSandbox Projects only supports **project-level** configuration. The secrets and environment variables are shared across all VMs, but it's necessary to restart your workspace after making changes for them to take effect.
+Currently, CodeSandbox Repositories only support **project-level** configuration. The secrets and environment variables are shared across all VMs, but you need to restart your workspace after making changes for them to take effect.
 
 ### Storage and Encryption
 
-Environment variables are stored in our database, AES encrypted. The encryption key is rerolled from time to time on an unannounced schedule and the key is stored separately from the database.
+Environment variables are stored in our database, AES-encrypted. The encryption key is rerolled from time to time on an unannounced schedule and it is stored separately from the database.
 
 ### Privacy
 
@@ -32,12 +32,12 @@ Environment variables are enabled only for **private** repositories and they are
 1. Open your project in the Web Editor.
 2. Open the **Menu** through the icon in the top left corner.
 
-![CodeSandbox Projects Editor Menu](../images/env-var-menu.jpg)
+![CodeSandbox Editor Menu](../images/env-var-menu.jpg)
 
 3. Click on the **`Env variables`** item.
 4. Add your configurations.
 
-![CodeSandbox Projects Environment Variables](../images/env-var-modal.jpg)
+![CodeSandbox Environment Variables](../images/env-var-modal.jpg)
 
 5. From the Editor's menu, press `Restart` to reload the workspace.
 
@@ -47,7 +47,7 @@ Environment variables are enabled only for **private** repositories and they are
 1. From the Editor, open the command palette using <kbd>⌘</kbd> + <kbd>K</kbd>. 
 2. Type `Add environment variables`.
 
-![CodeSandbox Projects Command Palette](../images/env-var-pallette.jpg)
+![CodeSandbox Command Palette](../images/env-var-pallette.jpg)
 3. Add and your configurations.
 4. From the editor's menu, click to `Restart` the workspace.
 
@@ -56,6 +56,6 @@ Environment variables are enabled only for **private** repositories and they are
 
 ### Manage environment variables and secrets
 
-You can review and change the existing environment variables and secrets by acessing them at any time throught the `Environment variables` link at the Editor's menu. For any changes to take effect, don't forget to  restart your workspace.
+You can review and change the existing environment variables and secrets by acessing them at any time throught the `Environment variables` link in the Editor's menu. Don't forget to restart your workspace so that any changes take effect.
 
-![CodeSandbox Projects Editor Menu](../images/env-var-menu-link.jpg)
+![CodeSandbox Editor Menu](../images/env-var-menu-link.jpg)

--- a/packages/projects-docs/pages/learn/repositories/task.md
+++ b/packages/projects-docs/pages/learn/repositories/task.md
@@ -1,32 +1,32 @@
 ---
 title: Task
-description: 
+description: Learn how you can use tasks to run commands with a click or on setup.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
 
 # Task
 
-![CodeSandbox Projects Task](../images/devtools-cover-tasks.jpg)
+![CodeSandbox Task](../images/devtools-cover-tasks.jpg)
 
 Tasks allow you to define commands (like `yarn start`) that you can run in a single click or on setup. These tasks are shared between all the clients connected to that branch.
 
-## Add new task
+## Adding a new task
 
-To add a new task and make it available from the menu, go to the Devtools dropdown, select `Tasks` and click on `New Task`. It will open the command palette where you can type the desired command and press enter. 
+To add a new task and make it available from the menu, go to the DevTools dropdown, select `Tasks` and click on `New Task`. This will open the command palette where you can type the desired command and press enter. 
 
 <Callout emoji="⭑">
-To make a task available to all branches, you need to commit and merge the `tasks.json` to main.
+To make a task available on all branches, you need to commit and merge `tasks.json` to main.
 </Callout>
 
 <br/>
 <br/>
 # Configuring Tasks
 
-CodeSandox Repositories can be configured through the `.codesandbox/tasks.json` configuration file in your repository. This file defines the steps to set up VMs and configures the running commands inside the workspace (webservers, Docker containers, tests etc.).
+CodeSandbox Repositories can be configured through the `.codesandbox/tasks.json` configuration file in your repository. This file defines the steps to set up VMs and configures the running commands inside the workspace (webservers, Docker containers, tests, etc.).
 
 <Callout emoji="⭑">
-Checking these files into version control is recommended to ensure that every collaborator has a similar editing experience. This configuration can be tracked and additional changes can be made to specific branches. In addition, once the file is merged to your main branch, every new branch will follow the same configuration.
+Checking these files into version control is recommended to ensure that every collaborator has a similar editing experience. This configuration can be tracked and additional changes can be made to specific branches. In addition, once the file is merged into your main branch, every new branch will follow the same configuration.
 </Callout>
 
 This is an example of a configuration:
@@ -50,11 +50,11 @@ This is an example of a configuration:
 
 ## Default configuration
 
-By default, CodeSandbox Repositories tries to infer scripts from the `package.json` file in your repositories's root folder. In addition, you can always use the terminal devtool to execute any shell script to run your repositories.
+By default, CodeSandbox Repositories tries to infer scripts from the `package.json` file in your Repositories' root folder. In addition, you can always use the terminal DevTool to execute any shell script to run your repositories.
 
-## Setup Tasks
+## Setup tasks
 
-Setup tasks are an array of commands that will run sequentially before the workspace is ready to start your application. If no value is provided, `installing dependencies` will be the default task (we will detect which package manager you use).
+Setup tasks are an array of commands that will run sequentially before the workspace is ready to start your application. If no value is provided, `installing dependencies` will be the default task (CodeSandbox will detect which package manager you use).
 
 ```json
 {
@@ -73,7 +73,7 @@ Setup tasks are an array of commands that will run sequentially before the works
 
 ## Tasks Configuration
 
-Tasks are scripts that can be run inside your repository. In many cases these will call the scripts in your `package.json`, but they can also be used to run other executables.
+Tasks are scripts that can be run inside your repository. In many cases, these will call the scripts in your `package.json`, but they can also be used to run other executables.
 
 ```json
 {
@@ -107,17 +107,17 @@ Tasks are scripts that can be run inside your repository. In many cases these wi
 }
 ```
 
-The task id does not appear on the UI, since each task has a display name configured alongside the command it runs.
+The task ID does not appear on the UI, since each task has a display name configured alongside the command it runs.
 
 ### `preview` field
 
-You can define the `preview` field for tasks. By setting the `preview` field, we will directly put a link of the preview for the given task in every GitHub PR (if the [GitHub App](/learn/integrations/github-app) is installed), and we'll create deployments for them.
+You can define the `preview` field for tasks. By setting the `preview` field, we will directly place a link to the preview for the given task in every GitHub PR (if the [GitHub App](/learn/integrations/github-app) is installed), and we'll create deployments for them.
 
-The `preview` object has two fields: `port` and `prLink`. The `port` field defines the port that this task opens, and the `prLink` defines how PRs should link to this port. The possible options are `direct` and `devtool`.
+The `preview` object has two fields: `port` and `prLink`. The `port` field defines the port that this task opens, and `prLink` defines how PRs should link to this port. The possible options are `direct` and `devtool`.
 
 With `direct`, you will directly open the preview URL from the PR.
 
-With `devtool`, you will open the preview URL with an experimental devtool inside the preview.
+With `devtool`, you will open the preview URL with an experimental DevTool inside the preview.
 
 Here's an example:
 

--- a/packages/projects-docs/pages/learn/repositories/tasks.md
+++ b/packages/projects-docs/pages/learn/repositories/tasks.md
@@ -7,7 +7,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # .codesandbox/tasks.json
 
-CodeSandox Projects can be configured through the `.codesandbox/tasks.json` configuration file in your project. This file defines the steps to set up VMs and configures the running commands inside the workspace (webservers, Docker containers, tests etc.).
+CodeSandbox Repositories can be configured through the `.codesandbox/tasks.json` configuration file in your project. This file defines the steps to set up VMs and configures the running commands inside the workspace (webservers, Docker containers, tests etc.).
 
 <Callout emoji="⭑">
 Checking these files into version control is recommended to ensure that every collaborator has a similar editing experience. This configuration can be tracked and additional changes can be made to specific branches. In addition, once the file is merged to your main branch, every new branch will follow the same configuration.
@@ -34,7 +34,7 @@ This is an example of a configuration:
 
 ## Default configuration
 
-By default, CodeSandbox Projects tries to infer scripts from the `package.json` file in your project's root folder. In addition, you can always use the terminal devtool to execute any shell script to run your project.
+By default, CodeSandbox tries to infer scripts from the `package.json` file in your project's root folder. In addition, you can always use the terminal devtool to execute any shell script to run your project.
 
 ## Setup Tasks
 

--- a/packages/projects-docs/pages/learn/repositories/terminal.md
+++ b/packages/projects-docs/pages/learn/repositories/terminal.md
@@ -1,21 +1,21 @@
 ---
 title: Terminal
-description: 
+description: Use a terminal right from CodeSandbox, just like your local terminal.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
 
 # Terminal
 
-![CodeSandbox Projects Terminal](../images/devtools-cover-terminal.jpg)
+![CodeSandbox Repositories Terminal](../images/devtools-cover-terminal.jpg)
  
-One of the benefits of working on CodeSandbox Projects is running the terminal without ever leaving the Web Editor. The Terminal Devtool is connected to a Virtual Machine and behaves like your local terminal, accepting any commands you are used to running, such as:
+One of the benefits of working on CodeSandbox Repositories is running the terminal without ever leaving the Web Editor. The Terminal DevTool is connected to a Virtual Machine and behaves like your local terminal, accepting any commands you are used to running, such as:
 - git operations
 - bash scripts
 - package-management commands
 - start servers
 
-Besides opening a fresh instance, you can also see other people's terminals. This is specially useful when someone on your team encounters errors or has a hard time fixing a problem. You can quickly jump in and instantly understand what is going on.
+Besides opening a fresh instance, you can also see other people's terminals. This is especially useful when someone on your team encounters errors or has a hard time fixing a problem. You can quickly jump in and instantly understand what is going on.
 
 ![Collaborative Terminal](../images/devtools-terminalcolab.jpg)
 

--- a/packages/projects-docs/pages/learn/sandboxes/editors.md
+++ b/packages/projects-docs/pages/learn/sandboxes/editors.md
@@ -126,7 +126,7 @@ The code editor is where the magic happens ✨. We provide a base experience for
 - Multiple Editors
 - Diff view
 
- If you want more advanced features, you can scale the Sandbox to a Repository so you can access our [VSCode extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the project inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
+ If you want more advanced features, you can scale the Sandbox to a Repository so you can access our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the project inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
 
 ### DevTool
 

--- a/packages/projects-docs/pages/learn/teams/team-overview.md
+++ b/packages/projects-docs/pages/learn/teams/team-overview.md
@@ -9,7 +9,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 In CodeSandbox Repositories, you can organize your work under Personal Repositories or Teams. Your teams are synced across Sandboxes and Repositories and every team member can navigate between the imported repositories. 
 
-![Teams in Projects](../images/teams-list.jpg)
+![Teams in Repositories](../images/teams-list.jpg)
 
 For repositories is granting visibility of all repositories to all team members by replicating the existing privacy settings already in place on GitHub. 
 

--- a/packages/projects-docs/pages/tutorial/cli-tool.md
+++ b/packages/projects-docs/pages/tutorial/cli-tool.md
@@ -1,20 +1,23 @@
 ---
 title: Install CLI tools and global modules
-description: Install cli tools and global modules inside CodeSandbox Projects
+description: Install CLI tools and global modules inside CodeSandbox Repositories.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
 
 # Install CLI tools and global modules
 
-Please note due to security reasons in Projects you can’t run commands using sudo. On the other hand, we know it’s really important to set up your workspace as you wish and install additional tooling.
+Please note that, due to security reasons, you can’t run commands using `sudo` in CodeSandbox Repositories. On the other hand, we know it’s really important to set up your workspace as you wish and install additional tooling.
 
-By default `npm install -g` installs global modules into `/usr/local/lib/node_modules`
- and links executables into `/usr/local/bin`. So in Projects for these folders you have write access and you can install additional tools.
+By default, `npm install -g` installs global modules into `/usr/local/lib/node_modules`
+ and links executables into `/usr/local/bin`. So in Repositories, you have write access to these folders and you can install additional tools.
 
-Probably you’d like to install some frameworks that require write access to many more folders. So in cases like this, we recommend using Docker or NixOS 
+It is likely that at some point you will want to install some frameworks that require write access to several other folders. In cases like this, we recommend using Docker or NixOS.
 
-# Getting started with Docker and NixOS in Projects
+<br />
+<br />
+
+# Getting started with Docker and NixOS in Repositories
 
 ### 1. Click on + New task to install new tooling
 
@@ -24,28 +27,28 @@ Probably you’d like to install some frameworks that require write access to ma
 
 ![https://images.tango.us/public/screenshot_434878b2-cd08-4b6a-91bf-d03056e07d9f.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_434878b2-cd08-4b6a-91bf-d03056e07d9f.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008)
 
-### 3. You can see the progress of the installation in a console log.
+### 3. You can see the progress of the installation in a console log
 
 ![https://images.tango.us/public/screenshot_2c94b9c2-a668-427f-b7fa-bfcd60de9f29.png?crop=focalpoint&fit=crop&fp-x=0.7831&fp-y=0.2096&fp-z=2.3839&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_2c94b9c2-a668-427f-b7fa-bfcd60de9f29.png?crop=focalpoint&fit=crop&fp-x=0.7831&fp-y=0.2096&fp-z=2.3839&w=1200&ar=3892%3A3008)
 
-### 4. In the meantime a tasks.json file has been created under the .codesandbox folder
+### 4. In the meantime, a `tasks.json` file has been created in the `.codesandbox` folder
 
-With the tasks.json you can automate the creation of your development environment within Projects
+With `tasks.json`, you can automate the creation of your development environment within Repositories.
 
 ![https://images.tango.us/public/screenshot_b1d911c4-953b-4648-a7c7-d72862a272b8.png?crop=focalpoint&fit=crop&fp-x=0.0812&fp-y=0.0938&fp-z=2.2900&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_b1d911c4-953b-4648-a7c7-d72862a272b8.png?crop=focalpoint&fit=crop&fp-x=0.0812&fp-y=0.0938&fp-z=2.2900&w=1200&ar=3892%3A3008)
 
-### 5. By default, your tool saved as a simple task
+### 5. By default, your tool is saved as a simple task
 
-You can run tasks from the UI or the Command Palette but global modules should be installed during setting up your environment.
+You can run [tasks](/learn/repositories/task) from the UI or the Command Palette but global modules should be installed during the setup of your environment.
 
 ![https://images.tango.us/public/screenshot_69be5dc2-5bc6-43f2-84c6-be9631c1178a.png?crop=focalpoint&fit=crop&fp-x=0.2885&fp-y=0.5402&fp-z=3.1717&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_69be5dc2-5bc6-43f2-84c6-be9631c1178a.png?crop=focalpoint&fit=crop&fp-x=0.2885&fp-y=0.5402&fp-z=3.1717&w=1200&ar=3892%3A3008)
 
-### 6. Let's move it under the setupTasks
+### 6. Move it under `setupTasks`
 
-So setupTasks will run every time Projects is setting up your workspace. What you have to do now is move the command up to under setupTasks. Also, don't forget to clean up tasks as you don't have to move every part of that entry created there.
+`setupTasks` will run every time Repositories is setting up your workspace. So now you have to move the command up to under `setupTasks`. Also, don't forget to clean up tasks as you don't have to move every part of that entry created there.
 
 <Callout emoji="⭑">
-Tip: Commit this file to your main branch. Only this way tasks will be picked up next time you create a new branch!
+Tip: Commit this file to your main branch. This is the only to ensure that tasks will be picked up next time you create a new branch!
 </Callout>
 
 ![https://images.tango.us/public/screenshot_4f27ab2c-2911-4294-924f-67a13e3139e1.png?crop=focalpoint&fit=crop&fp-x=0.3009&fp-y=0.2304&fp-z=2.1571&w=1200&ar=3892%3A3008](https://images.tango.us/public/screenshot_4f27ab2c-2911-4294-924f-67a13e3139e1.png?crop=focalpoint&fit=crop&fp-x=0.3009&fp-y=0.2304&fp-z=2.1571&w=1200&ar=3892%3A3008)

--- a/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
+++ b/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
@@ -1,15 +1,15 @@
 ---
 title: Getting started with Docker and NixOS
-description: Using docker and docker-compose with CodeSandbox Projects
+description: Using docker and docker-compose with CodeSandbox.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
 
 # Getting started with Docker and NixOS
 
-As an experimental feature, Docker and Nix are available within Projects. You can run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a `docker-compose` file in your root folder you have to run only `docker-compose up` and that's all, all your services will run within Projects.
+Docker and Nix are available within CodeSandbox Repositories as an experimental feature. You can run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a `docker-compose` file in your root folder, you only have to run `docker-compose up` - all your services will run within CodeSandbox Repositories.
 
-In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that takes a unique approach to package management and system configuration. Basically, you can install any additional tool, like java or Node v16, in your OS.
+In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that takes a unique approach to package management and system configuration. Basically, you can install any additional tool, like Java or Node v16, in your OS.
 
 ### 1. Click on the add a devtool dropdown
 
@@ -25,24 +25,28 @@ In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that tak
 
 ### 4. Opened ports will be picked up automatically
 
-If you run a development server for example inside the container and it opens up a port then Projects will detect that automatically and make the preview available. You can open the preview from the Other Previews in this case.
+If you run a development server (for example inside the container) and it opens up a port, then CodeSandbox Repositories will detect that automatically and make the preview available. In this case, you can open the preview from the Other Previews submenu.
 
-![The devtools have an option with other previews. Selecting this option will shows a submenu with ports running the previews.](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F3a225439-9c75-4f67-a1f6-5946a097e3d8%2FUntitled.png?table=block&id=2c4272cf-8620-4bd5-a722-c5aaa5ddc2e4)
+![DevTools have an option with other previews. Selecting this option will show a submenu with ports running the previews.](https://www.notion.so/image/https%3A%2F%2Fs3-us-west-2.amazonaws.com%2Fsecure.notion-static.com%2F3a225439-9c75-4f67-a1f6-5946a097e3d8%2FUntitled.png?table=block&id=2c4272cf-8620-4bd5-a722-c5aaa5ddc2e4)
 
-### 5. If you would like to start the given container every time you create a new branch or even restart your projects then you can persist it as a task
+### 5. (Optional) Persist it as a task
+
+If you would like to start a given container every time you create a new branch or even restart your repositories, then you can persist it as a task, as shown below.
 
 ![When opening the devtools menu and selecting tasks, a submenu with your tasks and an option to add a new task is shown. The new task option is highlighted.](https://images.tango.us/public/screenshot_57812431-5034-451d-b6f6-9c41ee4a4d96.png?crop=focalpoint&fit=crop&fp-x=0.9399&fp-y=0.2041&fp-z=3.0619&w=1200&ar=3892%3A3008)
 
-### 6. Just paste the command to the Command Palette and Projects will create a configuration file
+### 6. Paste in the Command Palette
+
+Simply paste the command into the Command Palette and CodeSandbox Repositories will create a configuration file.
 
 ![The command palette is shown with an indicator that the current action is adding a task, and the command is pasted inside the input.](https://images.tango.us/public/screenshot_3378f1fc-cc81-4028-ab1a-fb206716d182.png?crop=focalpoint&fit=crop&fp-x=0.5000&fp-y=0.1577&fp-z=1.6881&w=1200&ar=3892%3A3008)
 
 ### 7. Put it in the right place in your configuration
 
-If you define it as a task you will be able to run the container from the UI. You can also put it under setupTask and in this case the container will start when you create a workspace next time.
+If you define this as a task, you will be able to run the container from the UI. You can also put it under `setupTask` - in this case, the container will start the next time you create a workspace.
 
 <Callout emoji="⭑">
-Tip: Commit your changes and add the configuration to your repository so Projects will be able to run the container for every newly created branch.
+Tip: Commit your changes and add the configuration to your repository so CodeSandbox can run the container for every newly created branch.
 </Callout>
 
 ![The tasks.json file is open in the editor and shows all tasks that exist for the project.](https://images.tango.us/public/screenshot_d470cb2e-7005-4caa-bcb6-218c104eb298.png?crop=focalpoint&fit=crop&fp-x=0.3920&fp-y=0.5279&fp-z=1.0592&w=1200&ar=3892%3A3008)

--- a/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
+++ b/packages/projects-docs/pages/tutorial/getting-started-with-docker.md
@@ -7,7 +7,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Getting started with Docker and NixOS
 
-Docker and Nix are available within CodeSandbox Repositories as an experimental feature. You can run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a `docker-compose` file in your root folder, you only have to run `docker-compose up` - all your services will run within CodeSandbox Repositories.
+Docker and Nix are available within CodeSandbox Repositories as an experimental feature. You can run and build images to run containers inside your project by opening a terminal and running `docker`. If you have a `docker-compose` file in your root folder, you only have to run `docker-compose up`. Then, all your services will run within CodeSandbox Repositories.
 
 In addition, [Nix](https://nixos.org/) is also supported. Nix is a tool that takes a unique approach to package management and system configuration. Basically, you can install any additional tool, like Java or Node v16, in your OS.
 

--- a/packages/projects-docs/pages/tutorial/install-system-packages.md
+++ b/packages/projects-docs/pages/tutorial/install-system-packages.md
@@ -1,28 +1,25 @@
 ---
 title: Install system packages
-description: Install system packages inside CodeSandbox Projects as you're used to do on linux or mac
+description: Install system packages inside CodeSandbox Repositories as you're used to do on Linux or Mac.
 ---
 
 import Callout from 'nextra-theme-docs/callout'
 
 # Install system packages
 
-For many modules or tools probably you'd like to install some packages. Unfortunately, due to security reasons in Projects you can’t run commands using sudo but you can use Nix as a drop in replacement. You can read about this more on the [workspace limitations page](../../learn/setting-up/limitations). 
-Actually, most of the packages are available in [Nix](https://nixos.org/) as well so what you have to do is replace the `sudo apt-get install` or `sudo apt install` to `nix-env -i`, and that's all. You can check out the available packages in Nix on [https://search.nixos.org/packages](https://search.nixos.org/packages).
+When using some modules or tools, you may want to install some packages. Unfortunately, due to security reasons, you can’t run commands using `sudo` in CodeSandbox Repositories - but you can use Nix as a drop-in replacement. You can read about this more on the [workspace limitations page](../../learn/setting-up/limitations).
 
-For example, you can install Google Chrome as you see below:
+Fortunately, [Nix](https://nixos.org/) provides most of the packages that you will likely need. You just have to replace the commands for `sudo apt-get install` or `sudo apt install` with `nix-env -i` - that's all. You can check out the available packages in Nix on [https://search.nixos.org/packages](https://search.nixos.org/packages).
 
-On Debian you can run: `sudo apt install chromium`
-
-Inside CodeSandbox Projects just run `nix-env -i chromium`
+For example, to install Google Chrome on Debian, you would use `sudo apt install chromium`. In CodeSandbox Repositories, just run `nix-env -i chromium` and you will get the same result.
 
 <Callout emoji="⭑">
-Tip: Don't forget to add this command as a [setup task](../../learn/setting-up/tasks) so you don't have to run this command on every newly created branch, Projects will make it available for you immediately!
+Tip: Don't forget to add this command as a [setup task](../../learn/setting-up/tasks) so that you don't have to run this command on every newly created branch. CodeSandbox Repositories will make it available for you immediately!
 </Callout>
 
-As an alternative apporach to install packages, you can define a file in the root of your project called `csb.nix` and configure which packages should be automatically installed from the [nix package store](https://search.nixos.org/packages). In order to use this configuration on every branch you have to commit this file back to your main branch.
+As an alternative approach to installing packages, you can define a file in the root of your project called `csb.nix` and configure which packages should be automatically installed from the [Nix package store](https://search.nixos.org/packages). To use this configuration on every branch, you have to commit this file back to your main branch.
 
-An example configuration is this:
+Se an example configuration below:
 
 ```nix
 with import <nixpkgs> {};

--- a/packages/projects-docs/pages/tutorial/install-system-packages.md
+++ b/packages/projects-docs/pages/tutorial/install-system-packages.md
@@ -7,7 +7,7 @@ import Callout from 'nextra-theme-docs/callout'
 
 # Install system packages
 
-When using some modules or tools, you may want to install some packages. Unfortunately, due to security reasons, you can’t run commands using `sudo` in CodeSandbox Repositories - but you can use Nix as a drop-in replacement. You can read about this more on the [workspace limitations page](../../learn/setting-up/limitations).
+When using some modules or tools, you may want to install some packages. Unfortunately, due to security reasons, you can't run commands using `sudo` in CodeSandbox Repositories - but you can use Nix as a drop-in replacement. You can read about this more on the [workspace limitations page](../../learn/setting-up/limitations).
 
 Fortunately, [Nix](https://nixos.org/) provides most of the packages that you will likely need. You just have to replace the commands for `sudo apt-get install` or `sudo apt install` with `nix-env -i` - that's all. You can check out the available packages in Nix on [https://search.nixos.org/packages](https://search.nixos.org/packages).
 
@@ -19,7 +19,7 @@ Tip: Don't forget to add this command as a [setup task](../../learn/setting-up/t
 
 As an alternative approach to installing packages, you can define a file in the root of your project called `csb.nix` and configure which packages should be automatically installed from the [Nix package store](https://search.nixos.org/packages). To use this configuration on every branch, you have to commit this file back to your main branch.
 
-Se an example configuration below:
+See an example configuration below:
 
 ```nix
 with import <nixpkgs> {};


### PR DESCRIPTION
These updates are split into four main parts:

1. Update "CodeSandox Projects" and "Projects" mentions to "CodeSandox Repositories" and "Repositories", respectively.
2. Update "VSCode" to "VS Code".
3. Update "Github" to "GitHub".
4. Fix some typos and restructure some sentences for improved readability across several pages.

Note that the "Workspace" page is not up to date in this PR, considering the recent [PR](https://github.com/codesandbox/docs/pull/89) from @necoline.