### PR TITLE
Add info about VS Code support for Cloud Sandboxes

### DIFF
--- a/packages/projects-docs/pages/learn/introduction/overview.md
+++ b/packages/projects-docs/pages/learn/introduction/overview.md
@@ -34,7 +34,7 @@ CodeSandbox provides many alternatives for you to code. Each option is built to 
 <WrapContent>
 ## Keep working on VS Code
 
-**Install the CodeSandbox Projects VS Code extension and open any branch directly in your VS Code editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
+**Install the CodeSandbox Projects VS Code extension and open any branch or cloud sandbox directly in your VS Code editor.** Work from your local environment with your own configurations and shortcuts whilst remaining connected to the CodeSandbox development environment.
 
 <div className="ctaContainer">
     <ButtonDoc title={<>Get the <br/>VS Code Extension</>} cta="Install" description="" link="https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects" />

--- a/packages/projects-docs/pages/learn/repositories/editors.md
+++ b/packages/projects-docs/pages/learn/repositories/editors.md
@@ -50,10 +50,10 @@ The sidebar is a quick way to operate and navigate your codebase. It allows you 
 - Search inside your Repository
 - Interact with source control
 
-You can change the sidebar view using the icons in the top. 
+You can change the sidebar view using the icons at the top. 
 
 <Callout emoji="⭑">
-    You can drag and drop elements and shift or command click to select multiple itens in the lists. 
+    You can drag and drop elements and shift or command click to select multiple items in the lists. 
 </Callout>
 
 ### Code Editor
@@ -71,7 +71,7 @@ The code editor is where the magic happens ✨. We provide a base experience for
 - Multiple Editors
 - Diff view
 
- If you want more advanced features, you can download our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the Repository inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
+ If you want more advanced features, you can download our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the Repository in your local IDE](../introduction/overview?tab=vs-code#keep-working-on-vs-code) with your own customizations.
 
 ### DevTool
 
@@ -191,7 +191,7 @@ Only people on your CodeSandbox team with permissions to the repository may join
 
 ### More Questions?
 
-For questions and support please use the community [discord server](https://discord.gg/R32XxEGp4s).
+For questions and support, please use the community [Discord server](https://discord.gg/R32XxEGp4s).
     </WrapContent>
      <WrapContent>
      CodeSandbox for iOS support for Sandbox development is powered by the app’s Node.js port, it enables offline development but it is limited by the restrictions imposed by iOS. To unleash the full potential of developing on iOS you can use CodeSandbox Repositories. Repositories allows you to have the same experience across different devices but making the most of each platform’s potential.

--- a/packages/projects-docs/pages/learn/sandboxes/editors.md
+++ b/packages/projects-docs/pages/learn/sandboxes/editors.md
@@ -13,7 +13,7 @@ import Video from '../../../../../shared-components/Video'
 
 CodeSandbox offers two web editors and an iOS editor. A Sandbox is either a Browser Sandbox or a Cloud Sandbox (read more [here](/learn/sandboxes/overview)). All Sandboxes are available on the iOS app. 
 
-CodeSandbox supports VS Code for Cloud Sandboxes and [Repositories](/learn/repositories/overview).
+CodeSandbox supports VS Code for [Cloud Sandboxes](/learn/sandboxes/overview?tab=cloud#what-is-a-cloud-sandbox) and [Repositories](/learn/repositories/overview).
 
 <Tabs tabs={["Browser", "Cloud", "iOS"]}>
     <WrapContent>

--- a/packages/projects-docs/pages/learn/sandboxes/editors.md
+++ b/packages/projects-docs/pages/learn/sandboxes/editors.md
@@ -13,7 +13,7 @@ import Video from '../../../../../shared-components/Video'
 
 CodeSandbox offers two web editors and an iOS editor. A Sandbox is either a Browser Sandbox or a Cloud Sandbox (read more [here](/learn/sandboxes/overview)). All Sandboxes are available on the iOS app. 
 
-CodeSandbox also supports VS Code for [Repositories](/learn/repositories/overview)
+CodeSandbox supports VS Code for Cloud Sandboxes and [Repositories](/learn/repositories/overview).
 
 <Tabs tabs={["Browser", "Cloud", "iOS"]}>
     <WrapContent>
@@ -105,10 +105,10 @@ The sidebar is a quick way to operate and navigate your codebase. It allows you 
 - Search inside your project
 - Interact with source control
 
-You can change the sidebar view using the icons in the top. 
+You can change the sidebar view using the icons at the top. 
 
 <Callout emoji="⭑">
-    You can drag and drop elements and shift or command click to select multiple itens in the lists. 
+    You can drag and drop elements and shift or command click to select multiple items in the lists. 
 </Callout>
 
 ### Code Editor
@@ -126,7 +126,7 @@ The code editor is where the magic happens ✨. We provide a base experience for
 - Multiple Editors
 - Diff view
 
- If you want more advanced features, you can scale the Sandbox to a Repository so you can access our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the project inyour local IDE](../getting-started/keep-working-on-vscode) with your own customizations.
+ If you want more advanced features, you can download our [VS Code extension](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and [open the Cloud Sandbox in your local IDE](../introduction/overview?tab=vs-code#keep-working-on-vs-code) with your own customizations.
 
 ### DevTool
 

--- a/packages/projects-docs/pages/learn/sandboxes/overview.md
+++ b/packages/projects-docs/pages/learn/sandboxes/overview.md
@@ -26,11 +26,12 @@ If your project requires advanced configuration, try using a Cloud Sandbox inste
     </WrapContent>
     <WrapContent>
        ## What is a Cloud Sandbox
-       Unlike Browser Sandboxes that run on your browser. Cloud Sandboxes run on a virtual machine. Cloud Sandboxes are great for any protoytyping needs, but they really shine when working on projects that require the use of the server. 
-       You can learn more about the editor and the unique functionalities of the cloud developer environment in [Repositories](/learn/repositories/overview). Cloud Sandboxes and Repositories run on the same infrastructure and use the same editor. The main distinctions between the two is that Sandboxes are built for prototyping while Repositories are built for full scale development. Once you scale a Sandbox to a Repository, you will have 
-       - Integration with VS Code
+       Unlike Browser Sandboxes that run on your browser, Cloud Sandboxes run on our microVMs. Cloud Sandboxes are great for any prototyping needs, but they really shine when working on projects that require the use of the server. 
+       You can learn more about the editor and the unique functionalities of the cloud developer environment in [Repositories](/learn/repositories/overview).
+       
+       Cloud Sandboxes and Repositories run on the same infrastructure and use the same editor. The main distinction between the two is that Sandboxes are built for prototyping while Repositories are built for full-scale development. Once you scale a Sandbox to a Repository, you will have:
        - Branching
-       - Git Tooling 
+       - Git tooling 
        - Full integration with GitHub
     </WrapContent>
      <WrapContent>


### PR DESCRIPTION
This PR updates existing pages to make it clear that Cloud Sandboxes now have VS Code support. It also fixes some typos and two broken links.