### PR TITLE
fix(docs): meta tags + edit link

### DIFF
--- a/packages/codesandbox-theme-docs/dist/index.js
+++ b/packages/codesandbox-theme-docs/dist/index.js
@@ -2439,7 +2439,8 @@ var DEFAULT_THEME = {
       }
       return /* @__PURE__ */ React39.createElement(Anchor, {
         className,
-        href: editUrl
+        href: editUrl,
+        target: "_blank"
       }, children);
     },
     text: "Edit this page"
@@ -2475,13 +2476,13 @@ var DEFAULT_THEME = {
     content: "@codesandbox"
   }), /* @__PURE__ */ React39.createElement("meta", {
     property: "og:title",
-    content: "CodeSandbox"
+    content: "CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
   }), /* @__PURE__ */ React39.createElement("meta", {
     property: "og:description",
     content: "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
   }), /* @__PURE__ */ React39.createElement("meta", {
     name: "apple-mobile-web-app-title",
-    content: "CodeSandbox"
+    content: "CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
   })),
   i18n: [],
   logo: /* @__PURE__ */ React39.createElement(React39.Fragment, null, /* @__PURE__ */ React39.createElement("span", {

--- a/packages/codesandbox-theme-docs/dist/index.js
+++ b/packages/codesandbox-theme-docs/dist/index.js
@@ -495,7 +495,12 @@ var getGitEditUrl = (filePath) => {
   const repo = gitUrlParse(config.docsRepositoryBase || "");
   if (!repo)
     throw new Error("Invalid `docsRepositoryBase` URL!");
-  return `${repo.href}/${filePath}`;
+  console.log(repo.href);
+  const url = new URL(repo.href);
+  if (filePath) {
+    url.searchParams.append("file", filePath);
+  }
+  return url.toString();
 };
 
 // src/utils/get-git-issue-url.ts
@@ -2425,7 +2430,7 @@ var DEFAULT_THEME = {
   },
   darkMode: true,
   direction: "ltr",
-  docsRepositoryBase: "https://github.com/shuding/nextra",
+  docsRepositoryBase: "https://github.com/codesandbox/docs",
   editLink: {
     component({ className, filePath, children }) {
       const editUrl = getGitEditUrl(filePath);
@@ -2442,9 +2447,9 @@ var DEFAULT_THEME = {
   feedback: {},
   footer: {
     component: Footer,
-    text: `MIT ${new Date().getFullYear()} \xA9 Nextra.`
+    text: `MIT ${new Date().getFullYear()} \xA9 CodeSandbox.`
   },
-  getNextSeoProps: () => ({ titleTemplate: "%s \u2013 Nextra" }),
+  getNextSeoProps: () => ({ titleTemplate: "%s \u2013 CodeSandbox" }),
   gitTimestamp({ timestamp }) {
     const { locale = DEFAULT_LOCALE } = useRouter8();
     return /* @__PURE__ */ React39.createElement(React39.Fragment, null, "Last updated on", " ", timestamp.toLocaleDateString(locale, {
@@ -2461,29 +2466,29 @@ var DEFAULT_THEME = {
     content: "en"
   }), /* @__PURE__ */ React39.createElement("meta", {
     name: "description",
-    content: "Nextra: the next docs builder"
+    content: "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
   }), /* @__PURE__ */ React39.createElement("meta", {
     name: "twitter:card",
     content: "summary_large_image"
   }), /* @__PURE__ */ React39.createElement("meta", {
     name: "twitter:site",
-    content: "@shuding_"
+    content: "@codesandbox"
   }), /* @__PURE__ */ React39.createElement("meta", {
     property: "og:title",
-    content: "Nextra: the next docs builder"
+    content: "CodeSandbox"
   }), /* @__PURE__ */ React39.createElement("meta", {
     property: "og:description",
-    content: "Nextra: the next docs builder"
+    content: "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
   }), /* @__PURE__ */ React39.createElement("meta", {
     name: "apple-mobile-web-app-title",
-    content: "Nextra"
+    content: "CodeSandbox"
   })),
   i18n: [],
   logo: /* @__PURE__ */ React39.createElement(React39.Fragment, null, /* @__PURE__ */ React39.createElement("span", {
     className: "nx-font-extrabold"
-  }, "Nextra"), /* @__PURE__ */ React39.createElement("span", {
+  }, "CodeSandbox"), /* @__PURE__ */ React39.createElement("span", {
     className: "nx-ml-2 nx-hidden nx-font-normal nx-text-gray-600 md:nx-inline"
-  }, "The Next Docs Builder")),
+  }, "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster")),
   logoLink: true,
   navbar: Navbar,
   navigation: {

--- a/packages/codesandbox-theme-docs/dist/index.js
+++ b/packages/codesandbox-theme-docs/dist/index.js
@@ -495,7 +495,6 @@ var getGitEditUrl = (filePath) => {
   const repo = gitUrlParse(config.docsRepositoryBase || "");
   if (!repo)
     throw new Error("Invalid `docsRepositoryBase` URL!");
-  console.log(repo.href);
   const url = new URL(repo.href);
   if (filePath) {
     url.searchParams.append("file", filePath);

--- a/packages/codesandbox-theme-docs/dist/index.js
+++ b/packages/codesandbox-theme-docs/dist/index.js
@@ -2458,32 +2458,8 @@ var DEFAULT_THEME = {
       year: "numeric"
     }));
   },
-  head: /* @__PURE__ */ React39.createElement(React39.Fragment, null, /* @__PURE__ */ React39.createElement("meta", {
-    name: "msapplication-TileColor",
-    content: "#fff"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    httpEquiv: "Content-Language",
-    content: "en"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    name: "description",
-    content: "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    name: "twitter:card",
-    content: "summary_large_image"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    name: "twitter:site",
-    content: "@codesandbox"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    property: "og:title",
-    content: "CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    property: "og:description",
-    content: "CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
-  }), /* @__PURE__ */ React39.createElement("meta", {
-    name: "apple-mobile-web-app-title",
-    content: "CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
-  })),
   i18n: [],
+  head: null,
   logo: /* @__PURE__ */ React39.createElement(React39.Fragment, null, /* @__PURE__ */ React39.createElement("span", {
     className: "nx-font-extrabold"
   }, "CodeSandbox"), /* @__PURE__ */ React39.createElement("span", {

--- a/packages/codesandbox-theme-docs/shared.config.js
+++ b/packages/codesandbox-theme-docs/shared.config.js
@@ -1,9 +1,3 @@
-import { useRouter } from "next/router";
-
-const FEEDBACK_LINK_WITH_TRANSLATIONS = {
-  "en-US": "Question? Give us feedback →",
-};
-
 export default {
   project: "https://codesandbox.io",
   unstable_flexsearch: {

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -35,7 +35,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         return null
       }
       return (
-        <Anchor className={className} href={editUrl}>
+        <Anchor className={className} href={editUrl} target="_blank">
           {children}
         </Anchor>
       )

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -1,21 +1,21 @@
 /* eslint sort-keys: error */
-import React, { isValidElement } from 'react'
-import { DocsThemeConfig, PageTheme } from './types'
-import { useRouter } from 'next/router'
-import { Anchor, Flexsearch, Footer, Navbar, TOC } from './components'
-import { DiscordIcon, GitHubIcon } from 'nextra/icons'
-import { MatchSorterSearch } from './components/match-sorter-search'
-import { useConfig } from './contexts'
-import { getGitEditUrl } from './utils'
+import React, { isValidElement } from "react";
+import { DocsThemeConfig, PageTheme } from "./types";
+import { useRouter } from "next/router";
+import { Anchor, Flexsearch, Footer, Navbar, TOC } from "./components";
+import { DiscordIcon, GitHubIcon } from "nextra/icons";
+import { MatchSorterSearch } from "./components/match-sorter-search";
+import { useConfig } from "./contexts";
+import { getGitEditUrl } from "./utils";
 
-export const DEFAULT_LOCALE = 'en-US'
+export const DEFAULT_LOCALE = "en-US";
 
-export const IS_BROWSER = typeof window !== 'undefined'
+export const IS_BROWSER = typeof window !== "undefined";
 
 export const DEFAULT_THEME: DocsThemeConfig = {
   banner: {
     dismissible: true,
-    key: 'nextra-banner'
+    key: "nextra-banner",
   },
   chat: {
     icon: (
@@ -23,54 +23,66 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         <DiscordIcon />
         <span className="nx-sr-only">Discord</span>
       </>
-    )
+    ),
   },
   darkMode: true,
-  direction: 'ltr',
-  docsRepositoryBase: 'https://github.com/codesandbox/docs',
+  direction: "ltr",
+  docsRepositoryBase: "https://github.com/codesandbox/docs",
   editLink: {
     component({ className, filePath, children }) {
-      const editUrl = getGitEditUrl(filePath)
+      const editUrl = getGitEditUrl(filePath);
       if (!editUrl) {
-        return null
+        return null;
       }
       return (
         <Anchor className={className} href={editUrl} target="_blank">
           {children}
         </Anchor>
-      )
+      );
     },
-    text: 'Edit this page'
+    text: "Edit this page",
   },
   feedback: {},
   footer: {
     component: Footer,
-    text: `MIT ${new Date().getFullYear()} © CodeSandbox.`
+    text: `MIT ${new Date().getFullYear()} © CodeSandbox.`,
   },
-  getNextSeoProps: () => ({ titleTemplate: '%s – CodeSandbox' }),
+  getNextSeoProps: () => ({ titleTemplate: "%s – CodeSandbox" }),
   gitTimestamp({ timestamp }) {
-    const { locale = DEFAULT_LOCALE } = useRouter()
+    const { locale = DEFAULT_LOCALE } = useRouter();
     return (
       <>
-        Last updated on{' '}
+        Last updated on{" "}
         {timestamp.toLocaleDateString(locale, {
-          day: 'numeric',
-          month: 'long',
-          year: 'numeric'
+          day: "numeric",
+          month: "long",
+          year: "numeric",
         })}
       </>
-    )
+    );
   },
   head: (
     <>
       <meta name="msapplication-TileColor" content="#fff" />
       <meta httpEquiv="Content-Language" content="en" />
-      <meta name="description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
+      <meta
+        name="description"
+        content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
+      />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@codesandbox" />
-      <meta property="og:title" content="CodeSandbox" />
-      <meta property="og:description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
-      <meta name="apple-mobile-web-app-title" content="CodeSandbox" />
+      <meta
+        property="og:title"
+        content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
+      />
+      <meta
+        property="og:description"
+        content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
+      />
+      <meta
+        name="apple-mobile-web-app-title"
+        content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
+      />
     </>
   ),
   i18n: [],
@@ -78,7 +90,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     <>
       <span className="nx-font-extrabold">CodeSandbox</span>
       <span className="nx-ml-2 nx-hidden nx-font-normal nx-text-gray-600 md:nx-inline">
-        CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster
+        CodeSandbox is an online code editor and prototyping tool that makes
+        creating and sharing web apps faster
       </span>
     </>
   ),
@@ -86,19 +99,19 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   navbar: Navbar,
   navigation: {
     next: true,
-    prev: true
+    prev: true,
   },
   nextThemes: {
-    defaultTheme: 'system',
-    storageKey: 'theme'
+    defaultTheme: "system",
+    storageKey: "theme",
   },
   notFound: {
-    content: 'Submit an issue about broken link →',
-    labels: 'bug'
+    content: "Submit an issue about broken link →",
+    labels: "bug",
   },
   primaryHue: {
     dark: 204,
-    light: 212
+    light: 212,
   },
   project: {
     icon: (
@@ -106,16 +119,16 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         <GitHubIcon />
         <span className="nx-sr-only">GitHub</span>
       </>
-    )
+    ),
   },
   search: {
     component({ className, directories }) {
-      const config = useConfig()
+      const config = useConfig();
       return config.unstable_flexsearch ? (
         <Flexsearch className={className} />
       ) : (
         <MatchSorterSearch className={className} directories={directories} />
-      )
+      );
     },
     emptyResult: (
       <span className="nx-block nx-select-none nx-p-8 nx-text-center nx-text-sm nx-text-gray-400">
@@ -123,78 +136,78 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       </span>
     ),
     placeholder() {
-      const { locale } = useRouter()
-      if (locale === 'zh-CN') return '搜索文档…'
-      if (locale === 'ru-RU') return 'Поиск документации…'
-      if (locale === 'fr-FR') return 'Rechercher de la documentation…'
-      return 'Search documentation…'
-    }
+      const { locale } = useRouter();
+      if (locale === "zh-CN") return "搜索文档…";
+      if (locale === "ru-RU") return "Поиск документации…";
+      if (locale === "fr-FR") return "Rechercher de la documentation…";
+      return "Search documentation…";
+    },
   },
   serverSideError: {
-    content: 'Submit an issue about error in url →',
-    labels: 'bug'
+    content: "Submit an issue about error in url →",
+    labels: "bug",
   },
   sidebar: {
     defaultMenuCollapseLevel: 2,
-    titleComponent: ({ title }) => <>{title}</>
+    titleComponent: ({ title }) => <>{title}</>,
   },
   toc: {
     component: TOC,
     float: true,
-    title: 'On This Page'
-  }
-}
+    title: "On This Page",
+  },
+};
 
 export const DEEP_OBJECT_KEYS = Object.entries(DEFAULT_THEME)
   .map(([key, value]) => {
     const isObject =
       value &&
-      typeof value === 'object' &&
+      typeof value === "object" &&
       !Array.isArray(value) &&
-      !isValidElement(value)
+      !isValidElement(value);
     if (isObject) {
-      return key
+      return key;
     }
   })
-  .filter(Boolean) as (keyof DocsThemeConfig)[]
+  .filter(Boolean) as (keyof DocsThemeConfig)[];
 
 export const LEGACY_CONFIG_OPTIONS: Record<string, string> = {
-  bannerKey: 'banner.key',
-  bodyExtraContent: 'main',
-  customSearch: 'search.component',
-  defaultMenuCollapsed: 'sidebar.defaultMenuCollapseLevel',
-  feedbackLabels: 'feedback.labels',
-  feedbackLink: 'feedback.content',
-  floatTOC: 'toc.float',
-  footerEditLink: 'editLink.text',
-  footerText: 'footer.text',
-  github: 'project.link',
-  nextLinks: 'navigation.next',
-  notFoundLabels: 'notFound.labels',
-  notFoundLink: 'notFound.content',
-  prevLinks: 'navigation.prev',
-  projectChat: 'chat',
-  projectChatLink: 'chat.link',
-  projectChatLinkIcon: 'chat.icon',
-  projectLink: 'project.link',
-  projectLinkIcon: 'project.icon',
-  searchPlaceholder: 'search.placeholder',
-  serverSideErrorLabels: 'serverSideError.labels',
-  serverSideErrorLink: 'serverSideError.content',
-  sidebarSubtitle: 'sidebar.titleComponent',
-  tocExtraContent: 'toc.extraContent',
-  unstable_searchResultEmpty: 'search.emptyResult'
-}
+  bannerKey: "banner.key",
+  bodyExtraContent: "main",
+  customSearch: "search.component",
+  defaultMenuCollapsed: "sidebar.defaultMenuCollapseLevel",
+  feedbackLabels: "feedback.labels",
+  feedbackLink: "feedback.content",
+  floatTOC: "toc.float",
+  footerEditLink: "editLink.text",
+  footerText: "footer.text",
+  github: "project.link",
+  nextLinks: "navigation.next",
+  notFoundLabels: "notFound.labels",
+  notFoundLink: "notFound.content",
+  prevLinks: "navigation.prev",
+  projectChat: "chat",
+  projectChatLink: "chat.link",
+  projectChatLinkIcon: "chat.icon",
+  projectLink: "project.link",
+  projectLinkIcon: "project.icon",
+  searchPlaceholder: "search.placeholder",
+  serverSideErrorLabels: "serverSideError.labels",
+  serverSideErrorLink: "serverSideError.content",
+  sidebarSubtitle: "sidebar.titleComponent",
+  tocExtraContent: "toc.extraContent",
+  unstable_searchResultEmpty: "search.emptyResult",
+};
 
 export const DEFAULT_PAGE_THEME: PageTheme = {
   breadcrumb: true,
   collapsed: false,
   footer: true,
-  layout: 'default',
+  layout: "default",
   navbar: true,
   pagination: true,
   sidebar: true,
   timestamp: true,
   toc: true,
-  typesetting: 'default'
-}
+  typesetting: "default",
+};

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -12,6 +12,8 @@ export const DEFAULT_LOCALE = "en-US";
 
 export const IS_BROWSER = typeof window !== "undefined";
 
+const OG_IMAGE_URL = "https://codesandbox.io/docs/projects/og-image.jpg";
+
 export const DEFAULT_THEME: DocsThemeConfig = {
   banner: {
     dismissible: true,
@@ -71,6 +73,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@codesandbox" />
+      <meta name="twitter:image" content={OG_IMAGE_URL} />
       <meta
         property="og:title"
         content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
@@ -79,6 +82,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
         property="og:description"
         content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
       />
+      <meta name="og:image" content={OG_IMAGE_URL} />
       <meta
         name="apple-mobile-web-app-title"
         content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -12,8 +12,6 @@ export const DEFAULT_LOCALE = "en-US";
 
 export const IS_BROWSER = typeof window !== "undefined";
 
-const OG_IMAGE_URL = "https://codesandbox.io/docs/projects/og-image.jpg";
-
 export const DEFAULT_THEME: DocsThemeConfig = {
   banner: {
     dismissible: true,
@@ -63,33 +61,8 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       </>
     );
   },
-  head: (
-    <>
-      <meta name="msapplication-TileColor" content="#fff" />
-      <meta httpEquiv="Content-Language" content="en" />
-      <meta
-        name="description"
-        content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
-      />
-      <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:site" content="@codesandbox" />
-      <meta name="twitter:image" content={OG_IMAGE_URL} />
-      <meta
-        property="og:title"
-        content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
-      />
-      <meta
-        property="og:description"
-        content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster"
-      />
-      <meta name="og:image" content={OG_IMAGE_URL} />
-      <meta
-        name="apple-mobile-web-app-title"
-        content="CodeSandbox: Online Code Editor and IDE for Rapid Web Development"
-      />
-    </>
-  ),
   i18n: [],
+  head: null,
   logo: (
     <>
       <span className="nx-font-extrabold">CodeSandbox</span>

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -67,7 +67,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
       <meta httpEquiv="Content-Language" content="en" />
       <meta name="description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
       <meta name="twitter:card" content="summary_large_image" />
-      <meta name="twitter:site" content="@shuding_" />
+      <meta name="twitter:site" content="@codesandbox" />
       <meta property="og:title" content="CodeSandbox" />
       <meta property="og:description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
       <meta name="apple-mobile-web-app-title" content="CodeSandbox" />

--- a/packages/codesandbox-theme-docs/src/constants.tsx
+++ b/packages/codesandbox-theme-docs/src/constants.tsx
@@ -27,7 +27,7 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   },
   darkMode: true,
   direction: 'ltr',
-  docsRepositoryBase: 'https://github.com/shuding/nextra',
+  docsRepositoryBase: 'https://github.com/codesandbox/docs',
   editLink: {
     component({ className, filePath, children }) {
       const editUrl = getGitEditUrl(filePath)
@@ -45,9 +45,9 @@ export const DEFAULT_THEME: DocsThemeConfig = {
   feedback: {},
   footer: {
     component: Footer,
-    text: `MIT ${new Date().getFullYear()} © Nextra.`
+    text: `MIT ${new Date().getFullYear()} © CodeSandbox.`
   },
-  getNextSeoProps: () => ({ titleTemplate: '%s – Nextra' }),
+  getNextSeoProps: () => ({ titleTemplate: '%s – CodeSandbox' }),
   gitTimestamp({ timestamp }) {
     const { locale = DEFAULT_LOCALE } = useRouter()
     return (
@@ -65,20 +65,20 @@ export const DEFAULT_THEME: DocsThemeConfig = {
     <>
       <meta name="msapplication-TileColor" content="#fff" />
       <meta httpEquiv="Content-Language" content="en" />
-      <meta name="description" content="Nextra: the next docs builder" />
+      <meta name="description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
       <meta name="twitter:card" content="summary_large_image" />
       <meta name="twitter:site" content="@shuding_" />
-      <meta property="og:title" content="Nextra: the next docs builder" />
-      <meta property="og:description" content="Nextra: the next docs builder" />
-      <meta name="apple-mobile-web-app-title" content="Nextra" />
+      <meta property="og:title" content="CodeSandbox" />
+      <meta property="og:description" content="CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster" />
+      <meta name="apple-mobile-web-app-title" content="CodeSandbox" />
     </>
   ),
   i18n: [],
   logo: (
     <>
-      <span className="nx-font-extrabold">Nextra</span>
+      <span className="nx-font-extrabold">CodeSandbox</span>
       <span className="nx-ml-2 nx-hidden nx-font-normal nx-text-gray-600 md:nx-inline">
-        The Next Docs Builder
+        CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster
       </span>
     </>
   ),

--- a/packages/codesandbox-theme-docs/src/utils/get-git-edit-url.ts
+++ b/packages/codesandbox-theme-docs/src/utils/get-git-edit-url.ts
@@ -1,17 +1,16 @@
-import { useConfig } from '../contexts'
-import gitUrlParse from 'git-url-parse'
+import { useConfig } from "../contexts";
+import gitUrlParse from "git-url-parse";
 
 export const getGitEditUrl = (filePath?: string): string => {
-  const config = useConfig()
-  const repo = gitUrlParse(config.docsRepositoryBase || '')
+  const config = useConfig();
+  const repo = gitUrlParse(config.docsRepositoryBase || "");
 
-  if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
-  console.log(repo.href);
+  if (!repo) throw new Error("Invalid `docsRepositoryBase` URL!");
 
   const url = new URL(repo.href);
   if (filePath) {
-    url.searchParams.append('file', filePath);
+    url.searchParams.append("file", filePath);
   }
 
   return url.toString();
-}
+};

--- a/packages/codesandbox-theme-docs/src/utils/get-git-edit-url.ts
+++ b/packages/codesandbox-theme-docs/src/utils/get-git-edit-url.ts
@@ -6,6 +6,12 @@ export const getGitEditUrl = (filePath?: string): string => {
   const repo = gitUrlParse(config.docsRepositoryBase || '')
 
   if (!repo) throw new Error('Invalid `docsRepositoryBase` URL!')
+  console.log(repo.href);
 
-  return `${repo.href}/${filePath}`
+  const url = new URL(repo.href);
+  if (filePath) {
+    url.searchParams.append('file', filePath);
+  }
+
+  return url.toString();
 }

--- a/packages/projects-docs/theme.config.js
+++ b/packages/projects-docs/theme.config.js
@@ -3,14 +3,15 @@ import BackLink from "../../shared-components/BackLink";
 import defaultConfigs from "codesandbox-theme-docs/shared.config.js";
 import { useConfig } from "nextra-theme-docs";
 
+const OG_IMAGE_URL = "https://codesandbox.io/docs/projects/og-image.jpg";
+
 export default {
   ...defaultConfigs,
   docsRepositoryBase: "https://codesandbox.io/p/github/codesandbox/docs/main",
   titleSuffix: " - CodeSandbox",
   project: { icon: BackLink },
   gitTimestamp: null,
-  getNextSeoProps() {
-    const ogImage = "https://codesandbox.io/docs/projects/og-image.jpg";
+  head() {
     const { frontMatter } = useConfig();
 
     return (
@@ -33,7 +34,7 @@ export default {
         />
         <meta name="twitter:card" content="summary_large_image" />
         <meta name="twitter:site" content="@codesandbox" />
-        <meta name="twitter:image" content={ogImage} />
+        <meta name="twitter:image" content={OG_IMAGE_URL} />
         <meta
           name="og:title"
           content={
@@ -42,7 +43,7 @@ export default {
               : "CodeSandbox Documentation"
           }
         />
-        <meta name="og:image" content={ogImage} />
+        <meta name="og:image" content={OG_IMAGE_URL} />
       </>
     );
   },


### PR DESCRIPTION
### Replaces references to `Nextra` in the meta tags.

Right now, when we share links to the docs, the generated previews mention Nextra instead of CodeSandbox:

![Screen Shot 2022-12-01 at 15 10 37](https://user-images.githubusercontent.com/24959348/205128572-430cf24d-203f-46bc-a109-ac95b77c2988.png)

After this gets merged, it will show the same content as when we share the website:

**Title**: CodeSandbox: Online Code Editor and IDE for Rapid Web Development
**Description**: CodeSandbox is an online code editor and prototyping tool that makes creating and sharing web apps faster

cc @filipelima18 if we want to change the content.

The Twitter user was also pointing to the library's creator instead of @codesandbox.

## Fixes the "Edit this page on CodeSandbox" link:

It currently builds a wrong URL leading to a broken experience when users try to edit the documentation by opening it in CodeSandbox.

**Current**:

https://user-images.githubusercontent.com/24959348/205129468-d70f82bf-414d-4e23-b662-9f39303bc4a2.mov

**Fixed**:


https://user-images.githubusercontent.com/24959348/205130152-20ade1c9-9131-499e-9974-9e268b442642.mov


