### PR TITLE
Extended explanation around node_modules visibility

### DIFF
--- a/packages/projects-docs/pages/learn/repositories/env.md
+++ b/packages/projects-docs/pages/learn/repositories/env.md
@@ -33,7 +33,7 @@ Memory snapshots (which allow instant resume of VMs) will be cleaned up after 7 
 
 ## Node Modules
 
-The `node_modules` folder is globally ignored. You can override this behaviour by adding `!node_modules` in your own project `.gitignore` file.
+The `node_modules` folder is globally ignored. You can override this behaviour by adding `!node_modules` in your own project `.gitignore` file. While this will add `node_modules` folders to git, they won't be displayed in the UI.
 
 ## Environment configuration
 


### PR DESCRIPTION
Closes XTE-227

We do not want to encourage people to work with node_modules directly at this point, and also do not want to provide ways to overgoe this. So a quick update in the documentation should clear that up. 