### PR TITLE
fix(docs): update internal broken links

### DIFF
--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -69,7 +69,7 @@ Single value configuration, type `string`, by default it is set to `"16"` .
 
 ## Docker support
 
-CodeSandbox supports running Docker containers inside any workspace. You can learn more about our Docker support in our [Docker documentation](./docker.md).
+CodeSandbox supports running Docker containers inside any workspace. You can learn more about our Docker support in our [Docker documentation](/learn/environment/docker).
 
 <Callout emoji="⭑">
 For a step-by-step guide, check out our tutorial [Getting started with Docker](/tutorial/getting-started-with-docker)

--- a/packages/projects-docs/pages/learn/introduction/workspace.md
+++ b/packages/projects-docs/pages/learn/introduction/workspace.md
@@ -15,7 +15,7 @@ By default, when you set up an account, you will get a free personal workspace. 
 
 ![Personal workspace](../images/workspace-personal-team.png)
 
-It also contains a section for your [open source contributions](/getting-started/open-source#introducing-contribution-branches).
+It also contains a section for your [open source contributions](/learn/getting-started/open-source#introducing-contribution-branches).
 
 ![My contribution branches](../images/workspace-my-contributions.png)
 

--- a/packages/projects-docs/pages/learn/teams/permissions.md
+++ b/packages/projects-docs/pages/learn/teams/permissions.md
@@ -13,7 +13,7 @@ Users with write access to a repository can enjoy the full feature set available
 
 ### Users with read-only access 
 
-Users with read-only access to the repository can browse the content of the project, check the previews and even execute a few tasks. To introduce changes, they need to create a contribution branch or fork the repository. For more information, visit the [Open source collaboration](../getting-started/open-source-collaboration) page.
+Users with read-only access to the repository can browse the content of the project, check the previews and even execute a few tasks. To introduce changes, they need to create a contribution branch or fork the repository. For more information, visit the [open source collaboration](/learn/getting-started/open-source) page.
 
 ### Anonymous users
 


### PR DESCRIPTION
This PR fixes some internal broken links in three Docs pages:
* [VM Config & Persistence](https://codesandbox.io/docs/learn/environment/vm)
* [Workspace](https://codesandbox.io/docs/learn/introduction/workspace)
* [User Permissions](https://codesandbox.io/docs/learn/teams/permissions)

I couldn't properly test this in the CodeSandbox preview (the Docs theme build failed), so I appreciate a review to double-check if the updated links are working as expected.