### PR TITLE
chore: fix build and update readme

### DIFF
--- a/.codesandbox/tasks.json
+++ b/.codesandbox/tasks.json
@@ -30,7 +30,7 @@
     },
     "build:theme": {
       "name": "Build theme",
-      "command": "pnpm build",
+      "command": "pnpm build:theme",
       "runAtStart": true
     },
     "separator": {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   ],
   "scripts": {
     "dev:theme": "pnpm --filter codesandbox-theme-docs dev",
-    "build:theme": "pnpm --filter codesandbox-theme-docs build:all",
+    "build:theme": "pnpm --filter codesandbox-theme-docs build",
     "dev:projects": "pnpm --filter projects-docs dev",
     "test:projects": "pnpm --filter projects-docs test-docs"
   },

--- a/packages/codesandbox-theme-docs/README.md
+++ b/packages/codesandbox-theme-docs/README.md
@@ -1,7 +1,3 @@
-# nextra-theme-docs
+# codesandbox-theme-docs
 
-A documentation site theme for [Nextra](https://github.com/shuding/nextra).
-
-## Example
-
-[nextra.vercel.app](https://nextra.vercel.app/)
+A documentation site theme for CodeSandbox built with [Nextra](https://github.com/shuding/nextra).

--- a/packages/codesandbox-theme-docs/package.json
+++ b/packages/codesandbox-theme-docs/package.json
@@ -31,7 +31,8 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
-    "build": "pnpm tsup && pnpm build:tailwind && pnpm minify:css",
+    "build": "tsup",
+    "build:all": "pnpm build && pnpm build:tailwind",
     "build:tailwind": "NODE_ENV=production pnpm postcss css/styles.css -o dist/style.css --verbose",
     "minify:css": "lightningcss --minify --nesting --bundle --targets '>= 0.25%' dist/style.css -o dist/style.css",
     "types": "tsup --dts-only",

--- a/packages/codesandbox-theme-docs/package.json
+++ b/packages/codesandbox-theme-docs/package.json
@@ -31,15 +31,15 @@
   },
   "scripts": {
     "dev": "concurrently \"pnpm dev:layout\" \"pnpm dev:tailwind\"",
-    "build": "tsup",
-    "build:all": "pnpm build && pnpm build:tailwind",
+    "bundle": "tsup",
+    "build": "pnpm bundle && pnpm build:tailwind",
     "build:tailwind": "NODE_ENV=production pnpm postcss css/styles.css -o dist/style.css --verbose",
     "minify:css": "lightningcss --minify --nesting --bundle --targets '>= 0.25%' dist/style.css -o dist/style.css",
     "types": "tsup --dts-only",
     "types:check": "tsc --noEmit",
     "dev:layout": "tsup --watch",
     "dev:tailwind": "TAILWIND_MODE=watch pnpm postcss css/styles.css -o dist/style.css --watch",
-    "prepublishOnly": "pnpm build:all",
+    "prepublishOnly": "pnpm build",
     "test": "vitest --run",
     "clean": "rimraf ./dist",
     "format": "prettier --ignore-path ../../.gitignore --write --list-different ."

--- a/packages/projects-docs/README.md
+++ b/packages/projects-docs/README.md
@@ -1,26 +1,9 @@
-# [SWR website](https://swr.vercel.app)
+# [CodeSandbox Docs](https://codesandbox.io/docs/learn/introduction/overview)
 
-The official website for [SWR](https://github.com/vercel/swr).
+The official documentation for CodeSandbox.
 
-The project uses [pnpm](https://pnpm.io), [Nextra](https://nextra.vercel.app) and deploys via [Vercel](https://vercel.com). To develop it locally, clone this repository and run the following command to start the local dev server:
-
-```bash
-pnpm install
-pnpm dev
-```
-
-And visit `localhost:3000` to preview your changes.
+The project uses [pnpm](https://pnpm.io), [Nextra](https://nextra.vercel.app) and deploys via [Vercel](https://vercel.com).
 
 ## Contributing
 
-When making a change, or creating a new page, please make sure to edit all language files. You can simply copy the content of the edited English document (or the edited paragraph) and apply it to other language files. And then, volunteers are welcome to help with any untranslated sections.
-
-## Contributors
-
-- https://github.com/vercel/swr-site/graphs/contributors
-- Simplified Chinese translation done by Fang Lu ([@huzhengen](https://github.com/huzhengen))
-- Spanish translation done by Markoz Peña ([@markozxuu](https://twitter.com/markozxuu))
-- Japanese translation done by uttk ([@uttk](https://github.com/uttk)), Tomohiro SHIOYA ([@shioyang](https://github.com/shioyang))
-- Korean translation done by SeulGi Choi ([@cs09g](https://github.com/cs09g))
-- Russian translation done by Valentin Politov ([@valentinpolitov](https://github.com/valentinpolitov))
-- Brazilian Portuguese translation done by Guilherme Sousa ([@guilherssousa](https://github.com/guilherssousa))
+You open the project in [CodeSandbox](https://codesandbox.io/p/github/codesandbox/docs) to explore and contribute.


### PR DESCRIPTION
The project isn't running in https://codesandbox.io/p/github/codesandbox/docs/main?file=%2Fpackage.json due to the build theme failing:

![Screen Shot 2023-01-18 at 16 57 50](https://user-images.githubusercontent.com/24959348/213281833-c58584a1-473a-491f-bfa8-b7fcee8a0a03.png)

This PR fixes the build scripts.

It also updates the readme for the theme and the project packages since they were referencing Nextra and SWR instead of CodeSandbox.