### PR TITLE
Update support for engines variable in package.json for node version detection.

### DIFF
--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -60,12 +60,23 @@ The environment file allows you to specify:
 **nodeVersion**
 
 ```json
+/* .codesandbox/environment.json */
+
 {
   "nodeVersion": "14"
 }
 ```
 
 Single value configuration, type `string`, by default it is set to `"16"` .
+
+<Callout emoji="*">
+If your package.json uses [engines](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) field then you need any `.nvmrc` or `environment.json` files. 
+</Callout>
+
+**Note:** This works only if you are using `pitcherv-v0.206.0` or higher. You can restart your vm anytime to load the latest version.
+
+
+If your project has all three ways of configuring node version. Then `.nvmrc` and `environment.json` gets the priority. If both of the files are missing then the node version that is specified in `package.json` file is used.
 
 ## Docker support
 

--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -73,7 +73,7 @@ Single value configuration, type `string`, by default it is set to `"16"` .
 If your package.json uses [engines](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) field then you need any `.nvmrc` or `environment.json` files. 
 </Callout>
 
-**Note:** This works only if you are using `pitcherv-v0.206.0` or higher. You can restart your vm anytime to load the latest version.
+**Note:** This works only if you are using `pitcherv-v0.236.0` or higher. You can restart your vm anytime to load the latest version.
 
 
 If your project has all three ways of configuring node version. Then `.nvmrc` and `environment.json` gets the priority. If both of the files are missing then the node version that is specified in `package.json` file is used.

--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -70,7 +70,7 @@ The environment file allows you to specify:
 Single value configuration, type `string`, by default it is set to `"16"` .
 
 <Callout emoji="*">
-If your package.json uses [engines](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) field then you need any `.nvmrc` or `environment.json` files. 
+If your package.json uses [engines](https://docs.npmjs.com/cli/v9/configuring-npm/package-json#engines) field then a `.nvmrc` or `environment.json` file is not needed. 
 </Callout>
 
 **Note:** This works only if you are using `pitcherv-v0.236.0` or higher. You can restart your vm anytime to load the latest version.


### PR DESCRIPTION
We recently added the ability on the pitcher to configure a VM's node version using `engines` filed in package.json. This is a npm standard field which is used to define the least version of node that a project needs. 

Till now, users can change a node version only through `environment.json` or `.nvmrc` files. If a project is already using a using `engines` filed in package.json they still need to create one of those files.  This latest change fixes it.

Here is the priority order for the detection

`.nvmrc` > `environment.json` > `package.json`