### PR TITLE
Update VM specs in docs

### DIFF
--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -14,7 +14,7 @@ Based on our analysis of usual resource needs, we have defined these resources a
 | Type    | Limit  |
 | ------- | ------ |
 | CPU     | 4 vCPU |
-| Memory  | 4Gi    |
+| Memory  | 6Gi    |
 | Storage | 8Gi    |
 
 But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. If you hit any limitations while using CodeSandbox, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.

--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -13,9 +13,9 @@ Based on our analysis of usual resource needs, we have defined these resources a
 
 | Type    | Limit  |
 | ------- | ------ |
-| CPU     | 4 vCPU |
-| Memory  | 6Gi    |
-| Storage | 8Gi    |
+| CPU     | 2 vCPU |
+| Memory  | 4Gi    |
+| Storage | 6Gi    |
 
 But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. If you hit any limitations while using CodeSandbox, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
 

--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -13,9 +13,9 @@ Based on our analysis of usual resource needs, we have defined these resources a
 
 | Type    | Limit  |
 | ------- | ------ |
-| CPU     | 2 vCPU |
-| Memory  | 4Gi    |
-| Storage | 6Gi    |
+| CPU     | 4 vCPU |
+| Memory  | 6Gi    |
+| Storage | 12Gi    |
 
 But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. If you hit any limitations while using CodeSandbox, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
 


### PR DESCRIPTION
when we say "we have defined these resources as default" are we talking about the baseline for pro?

Because the resources outlined in the docs don't align with free or pro specs, I changed it to match our pro specs since it was just one number off and I assume that is when we say we gauged for "usual resource needs" we had pro in mind, but since we don't mention pricing tiers here, I wasn't sure.

context: I came to update the specs after we changed the default [disk for free](https://linear.app/codesandbox/issue/XTD-593/update-pricing-info-to-reflect-new-disk-limits), but I don't know if we wanted to list free or pro specs here

