### PR TITLE
fix(docs): Update sidekick shortcut

### DIFF
--- a/packages/projects-docs/pages/learn/repositories/shortcuts.md
+++ b/packages/projects-docs/pages/learn/repositories/shortcuts.md
@@ -28,7 +28,7 @@ import { Tabs, WrapContent } from '../../../../../shared-components/Tabs'
 ⌃ `     |   Open new terminal
 ⌘ K     |   Open command palette
 ⌘ B     |   Toggle Sidebar
-⌘ .     |   Toggle Sidekick
+⌘ '     |   Toggle Sidekick
 ⌘ ⌥ N       |   New file
 
 <br/>


### PR DESCRIPTION
This simple PR updates the Keyboard Shortcuts page to reflect the new "Toggle Sidekick" shortcut. `⌘ .` now seems to trigger code actions instead.