### PR TITLE
docs(Environment): add details about microVMs + how we allocate resources

### DIFF
--- a/packages/projects-docs/pages/learn/environment/vm.md
+++ b/packages/projects-docs/pages/learn/environment/vm.md
@@ -1,11 +1,13 @@
 ---
 title: VM Configuration & Persistence
-description: The specs of our VMs and how we persist files
+description: The specs of our VMs and how we persist files.
 ---
 
 import { Callout } from 'nextra-theme-docs'
 
 # Environment
+
+CodeSandbox Repositories and Cloud Sandboxes run on [microVM technology](https://codesandbox.io/blog/how-we-clone-a-running-vm-in-2-seconds). Each branch and cloud sandbox gets its own microVM and their resources (shown below) are set to each one of these instances.
 
 ## Default resources
 
@@ -17,9 +19,9 @@ Based on our analysis of usual resource needs, we have defined these resources a
 | Memory  | 3Gi    |
 | Storage | 6Gi    |
 
-But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. To upgrade to higher specs, you can purchase [Pro](https://codesandbox.io/pro).
+But we can go higher, up to 12vCPUs, 16GB memory and 30GB storage. To upgrade to higher specs, you can ugrade to one of our [Pro plans](https://codesandbox.io/pro).
 
-If you require higher specs than default to Pro, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
+If you require specs that go beyond our Pro plan defaults, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
 
 ## Persistence
 


### PR DESCRIPTION
This PR fulfills two main purposes:

1. Add a brief intro about what microVMs are and where we use them on the Environment page.
2. Explain that each branch and cloud sandbox gets a microVM and the specs are set to each one.

This came up during a user interview.

I also took the opportunity to tweak some wording.