### PR TITLE
fix(Docs): fix tutorial nav with Python link

### DIFF
--- a/packages/projects-docs/pages/tutorial/_meta.json
+++ b/packages/projects-docs/pages/tutorial/_meta.json
@@ -1,5 +1,6 @@
 {
-  "getting-started-with-docker": "Getting started with Docker",
-  "cli-tool": "Install CLI tools and global modules",
-  "install-system-packages": "Install system packages"
+  "getting-started-with-docker": "Getting Started with Docker",
+  "cli-tool": "Install CLI Tools and Global Modules",
+  "install-system-packages": "Install System Packages",
+  "getting-started-with-python": "Getting Started with Python"
 }


### PR DESCRIPTION
I recently merged PR #130 but forgot to update the meta file that contains navigation. This PR fixes that.