### PR TITLE
fix(Docs): add a new redirect to the Repository Setup page

### DIFF
--- a/packages/projects-docs/next.config.js
+++ b/packages/projects-docs/next.config.js
@@ -218,6 +218,13 @@ module.exports = withTM(
           permanent: true,
         },
 
+        // Other redirects
+        {
+          source: "/learn/getting-started/your-first-repository",
+          destination: "/learn/getting-started/setting-up-repository",
+          permanent: true,
+        },
+
         // Projects
         // ---------------------------
         {


### PR DESCRIPTION
Recently, there was a major update to the [Repository Setup + Tips & Tricks](https://codesandbox.io/docs/learn/getting-started/setting-up-repository) page. The URL also changed but a redirect was not added.

This PR adds that missing redirect.