### PR TITLE
Update documentation for synced sandboxes.

### DIFF
--- a/packages/projects-docs/pages/learn/sandboxes/editors.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/editors.mdx
@@ -18,21 +18,8 @@ CodeSandbox supports VS Code for [Cloud Sandboxes](/learn/sandboxes/overview?tab
     <WrapContent>
 Browser sandboxes are sandboxes that fully run in the browser, and are made to run frontend JavaScript/TypeScript frameworks. If you would like to run backend services or databases, check Cloud Sandboxes.
     
-## Synced Sandboxes
-#### (previously called Repositories)
-
-With CodeSandbox you can import any GitHub repository as a sandbox. An imported sandbox will
-automatically stay in sync with the GitHub repository; if you make a commit to
-GitHub it will reflect immediately in the sandbox.
-
-For that reason we've made GitHub sandboxes immutable, this means that you
-cannot make direct changes to the sandbox itself. They are treated as
-[templates](/learn/sandboxes/templates), so you can fork from them. When you create a fork
-of a GitHub sandbox we will still keep a reference to the original GitHub
-repository. 
 
 
-<br/>
 ## Uploading Static Files
 
 It's sometimes desired to have either images or big files in a sandbox. We allow

--- a/packages/projects-docs/pages/learn/sandboxes/overview.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/overview.mdx
@@ -35,5 +35,15 @@ If your project requires advanced configuration, try using a Cloud Sandbox inste
        - Branching
        - Git tooling 
        - Full integration with GitHub
+       
+        ## Synced Sandboxes
+
+        With CodeSandbox you can import any GitHub repository, subfolder or branch as a synced cloud sandbox. 
+        
+        An imported sandbox will automatically stay in sync with the GitHub repository; this means that if you make a commit to GitHub it will reflect immediately in the sandbox.
+
+        For that reason we've made these GitHub synced sandboxes immutable, this means that you cannot make direct changes to the sandbox itself. 
+        
+        These sandboxes are then treated as [templates](/learn/sandboxes/templates), so you can fork and start a new project from them. When you create a fork of a GitHub sandbox we will still keep a reference to the original GitHub repository. 
     </WrapContent>
 </Tabs>


### PR DESCRIPTION
A short summary about Synced sandboxes was on the Editors page
- I moved this over to the overview category specifically under cloud sandboxes
- Provided more information on how they work and how they can be used as templates.