### PR TITLE
fix: small note on CodeSandbox CI support for cloud sandboxes

### DIFF
--- a/packages/projects-docs/pages/learn/sandboxes/ci.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/ci.mdx
@@ -1,6 +1,6 @@
 ---
 title: CodeSandbox CI
-authors: ['Ives van Hoorne']
+authors: ['Ives van Hoorne', 'Maria Clara']
 description:
   Here's what CodeSandbox CI is, how it will benefit you as a library
   maintainer, and how to set it up for your library.
@@ -73,13 +73,14 @@ These are all the configuration options you can set. They are all optional.
     "react": "build/node_modules/react",
     "react-dom": "build/node_modules/react-dom"
   },
-  // A list of sandboxes that you want generated for a PR, if this list
+  // A list of Browser Sandboxes that you want generated for a PR, if this list
   // is not set we will default to `vanilla`. The built library will automatically
   // be installed in the fork of these sandboxes in the place of the library. So if
   // you have a sandbox with `lodash`, and you built `lodash` and `vue`, we will only
   // replace `lodash` with the built version.
   // You can also set absolute paths to a directory in your repository. We will make sure
   // to generate a sandbox from the contents of that directory.
+  // Currently, Cloud Sandboxes are not supported.
   "sandboxes": ["vanilla", "new", "/examples/todomvc"],
   // Node.js version to use for building the PR.
   // Supported versions are "10" (10.24.1, default), "12" (12.22.12), "14" (14.21.1),


### PR DESCRIPTION
We don't support Cloud Sandboxes in the CI yet. This adds a small note to the docs mentioning it.

Closes SPT-245.