### PR TITLE
feat: add "$schema" reference to all "tasks.json"

### DIFF
--- a/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
+++ b/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
@@ -82,6 +82,7 @@ An example configuration could look like this:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "setupTasks": [
     {
       "name": "Installing Dependencies",

--- a/packages/projects-docs/pages/learn/integrations/tailscale.mdx
+++ b/packages/projects-docs/pages/learn/integrations/tailscale.mdx
@@ -89,6 +89,7 @@ The following example `.codesandbox/tasks.json` runs each of these commands as t
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     "docker-compose up": {
       "name": "Docker Compose",

--- a/packages/projects-docs/pages/learn/repositories/task.mdx
+++ b/packages/projects-docs/pages/learn/repositories/task.mdx
@@ -33,6 +33,7 @@ This is an example of a configuration:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "setupTasks": ["yarn install", "yarn build"],
   "tasks": {
     "install-dependencies": {
@@ -58,6 +59,7 @@ Setup tasks are an array of commands that will run sequentially before the works
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "setupTasks": [
     {
       "name": "Installing Dependencies",
@@ -77,6 +79,7 @@ Tasks are scripts that can be run inside your repository. In many cases, these w
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     // Task ID is used to uniquely identify each task, we use it to
     // keep track of the task even if the command changes
@@ -123,6 +126,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     "dev-server": {
       "name": "Start Dev Server",
@@ -145,6 +149,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     "run-dev": {
       "name": "App",
@@ -159,6 +164,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks":{
     "build":{
       "name":"Build Workspace",
@@ -187,17 +193,4 @@ Here's an example:
 
 ## Reference
 
-- setupTasks
-  - name
-  - command
-- tasks
-  - task-id
-    - name
-    - command
-    - runAtStart
-    - restartOn
-      - files
-      - branch
-    - preview
-      - port
-      - prLink
+- [JSON Schema for `tasks.json`](https://codesandbox.io/schemas/tasks.json)

--- a/packages/projects-docs/pages/learn/repositories/tasks.mdx
+++ b/packages/projects-docs/pages/learn/repositories/tasks.mdx
@@ -17,6 +17,7 @@ This is an example of a configuration:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "setupTasks": ["yarn install", "yarn build"],
   "tasks": {
     "install-dependencies": {
@@ -42,6 +43,7 @@ Setup tasks are an array of commands that will run sequentially before the works
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "setupTasks": [
     {
       "name": "Installing Dependencies",
@@ -61,6 +63,7 @@ Tasks are scripts that can be run inside your project. In many cases these will 
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     // Task ID is used to uniquely identify each task, we use it to
     // keep track of the task even if the command changes
@@ -107,6 +110,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     "dev-server": {
       "name": "Start Dev Server",
@@ -129,6 +133,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks": {
     "run-dev": {
       "name": "App",
@@ -143,6 +148,7 @@ Here's an example:
 
 ```json
 {
+  "$schema": "https://codesandbox.io/schemas/tasks.json",
   "tasks":{
     "build":{
       "name":"Build Workspace",
@@ -171,17 +177,4 @@ Here's an example:
 
 ## Reference
 
-- setupTasks
-  - name
-  - command
-- tasks
-  - task-id
-    - name
-    - command
-    - runAtStart
-    - restartOn
-      - files
-      - branch
-    - preview
-      - port
-      - prLink
+- [JSON Schema for `tasks.json`](https://codesandbox.io/schemas/tasks.json)


### PR DESCRIPTION
- Follow-up to https://github.com/codesandbox/codesandbox-applications/pull/2580
- Related to ECO-321

## Changes

Adds the `$schema` property into every `tasks.json` so our users would get auto-completion and validation of their `tasks.json` configurations. 

More motivation in [Linear](https://linear.app/codesandbox/issue/ECO-321/write-a-json-schema-for-tasksjson).