### PR TITLE
docs(Repositories): Add Branching Workflow section and fix grammar

### DIFF
--- a/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
+++ b/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
@@ -43,7 +43,7 @@ To write some code, you have three options:
 2. Click the “Branch” button in the header.
 3. [Toggle protection off](/learn/environment/branch-protection) for the `main` branch.
 
-Give it a try!
+Give it a try on the repository you imported!
 
 When we create the new branch, we create a clone of the `main` VM and switch it to the new branch. This new VM is an _exact_ copy of the original VM, down to the memory contents. Because of this, processes like dev servers are already started in the cloned VM.
 

--- a/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
+++ b/packages/projects-docs/pages/learn/getting-started/setting-up-repository.mdx
@@ -8,43 +8,60 @@ import { Callout } from 'nextra-theme-docs'
 # Repository Setup + Tips & Tricks
 
 
-This guide will help you get started with using CodeSandbox for your repo. It's a walk-through with a bunch of tips and tricks on how to get the most out of CodeSandbox!
+This guide will help you get started with using CodeSandbox for your repo. It's a walkthrough with a bunch of tips and tricks on how to get the most out of CodeSandbox!
 
-## Create a Team & Import Repository
+## Create a Team & Import a Repository
 
-To get started with CodeSandbox for your repo, we recommend to first create a team. You can do this at [the dashboard](https://codesandbox.io/dashboard), by clicking on the workspace on the left, and pressing “Create a new team”. You can optionally start a free trial, in case you want better VM specs and import a private repositories.
+To get started with CodeSandbox for your repo, we recommend creating a team first. You can do this at [the dashboard](https://codesandbox.io/dashboard), by clicking on the workspace on the left, and pressing “Create a new team”. You can optionally start a free trial, in case you want better VM specs and import private repositories.
 
 ![Pasted image 20230202132514.png](/team-creation.png)
 
 Once you've created the team, you can import a repository by clicking “Import from GitHub” and entering the URL of the GitHub repo. Once you've clicked “Import”, you're off to the races!
 
-<Callout emoji="💡">You can also type your repo without GitHub URL (e.g. “codesandbox/test-sandbox”) to import the repo.</Callout>
+<Callout emoji="💡">You can also type your repo without the GitHub URL (e.g. “codesandbox/test-sandbox”) to import the repo.</Callout>
 
-The first time when you import a repo, it can take a while. During first-time setup, we clone the repository into the VM and set up the folders for the project. However, after this setup we will create a memory snapshot of the VM, which will ensure that next VM loads (& clones!) will be fast. Now, let's take a look at editor setup!
+The first time when you import a repo, it can take a while. During first-time setup, we clone the repository into the VM and set up the folders for the project. However, after this setup, we will create a memory snapshot of the VM, which will ensure that all the following VM loads (& clones!) will be fast.
+
+Next, let's take a look at the editor setup!
 
 ## Editor & Workflow Setup
 
-CodeSandbox has an opinionated flow when it comes to working with repositories, and you can see hints of this in the editor. As soon as you enter the editor, you will see the current branch name in the header. Every branch has its own VM and is available through a unique URL. For example, if two people visit the URL for the `main` branch, they will be able to see the cursor, terminals and devtools of each-other.
+CodeSandbox has an opinionated flow when it comes to working with repositories, and you can see hints of this in the editor.
 
-<Callout emoji="💡">URLs for branches are predictable, if you want to open a specific branch, you can update the URL with thew new branch name, and we'll import & create an environment for that branch automatically.</Callout>
+As soon as you enter the editor, you will see the current branch name in the header. Every branch has its own VM and is available through a unique URL. For example, if two people visit the URL for the `main` branch, they will be able to see each other's cursor, terminals and DevTools.
+
+<Callout emoji="💡">URLs for branches are predictable. So, if you want to open a specific branch, you can update the URL with the new branch name, and we'll import & create an environment for that branch automatically.</Callout>
 
 Now it's time to write some code!
 
-The default branch is protected by default. This means that the branch is read-only, and will sync automatically with the branch on GitHub when new commits come in. To actually write some code, you need to create a new branch. You can do this by either typing some code, or by clicking the “Branch” button in the header. This will automatically create a new branch and a VM tied to that branch.
+### Branching Workflow
+
+On CodeSandbox, the `main` branch is protected by default. This means that it's read-only and will sync automatically with the branch on GitHub when new commits come in.
+
+To write some code, you have three options:
+1. (Recommended) Just start typing some code - we will create a new branch for you using seamless branching!
+2. Click the “Branch” button in the header.
+3. [Toggle protection off](/learn/environment/branch-protection) for the `main` branch.
+
+Give it a try!
 
 When we create the new branch, we create a clone of the `main` VM and switch it to the new branch. This new VM is an _exact_ copy of the original VM, down to the memory contents. Because of this, processes like dev servers are already started in the cloned VM.
 
 <Callout emoji="💡">Tip: you can start a Postgres database on the `main` branch, seed some data in it, and then every new branch created from `main` will have that data available.</Callout>
 
-As you can see, we automatically generated a new branch, starting with `draft/...`. This branch is not protected. So you can make changes, open terminals or open any other devtool. When you're ready to open a PR, you can either click “Create PR” in the header, or commit from the Git panel in the sidebar.
+As you can see, we automatically generated a new branch for you, starting with `draft/...`. This branch is not protected, so you can make changes, open terminals or open any other DevTool.
 
-<Callout emoji="⭐">New branches are not automatically created on GitHub. Only when you create a commit or rename the branch we'll push the branch to GitHub.</Callout>
+### Git Workflow
 
-Now, let's do some configuration to make your repository work in CodeSandbox.
+When you're ready to open a PR, you can either click “Create PR” in the header or commit from the Git panel in the sidebar.
+
+<Callout emoji="⚠️">New branches are not automatically created on GitHub. We only push the branch to GitHub when you create a commit or rename the branch.</Callout>
+
+Next, let's do some configuration to make your repository work in CodeSandbox.
 
 ### Environment Configuration
 
-Generally, we recommend to configure the environment with a `Dockerfile`. When Docker is enabled, any new terminal will open inside a container and you will have `root` access to install additional packages.
+Generally, we recommend configuring the environment with a `Dockerfile`. When Docker is enabled, any new terminal will open inside a container and you will have `root` access to install additional packages.
 
 To enable the Docker integration, you need to create a folder called `.codesandbox` in the root of your repo and put a file named `Dockerfile` in there. An example Dockerfile could look like this:
 
@@ -57,15 +74,15 @@ RUN apt update -y && apt install -y htop
 
 This will ensure that Node.js is installed, but you can make any changes to this `Dockerfile` to install additional language support or packages.
 
-<Callout emoji="⭐">Currently we only install Debian or Ubuntu based Docker images, because we install additional utilities like zsh and git on top of the image</Callout>
+<Callout emoji="⭐">Currently, we only install Debian or Ubuntu-based Docker images, because we install additional utilities like `zsh` and `git` on top of the image</Callout>
 
-After you've made changes to the `Dockerfile`, you should see a notification that prompts to rebuild the containers. Press “Yes”, and you'll see the setup tasks start again, with a new entry to build the image. The built image is cached, and available through VM cloning in other branches.
+After you've made changes to the `Dockerfile`, you should see a notification that prompts you to rebuild the containers. Press “Yes” and you'll see the setup tasks start again, with a new entry to build the image. The built image is cached and available through VM cloning in other branches.
 
-<Callout emoji="💡">There's also native `docker-compose` support! If you create a `docker-compose.yml` file in `.codesandbox`, we'll automatically run the services.</Callout>
+<Callout emoji="💡">CodeSandbox also has native `docker-compose` support! If you create a `docker-compose.yml` file in `.codesandbox`, we'll automatically run the services.</Callout>
 
 You don't have to mount or `ADD` any files from your workspace folder. We'll make sure that your repository is mounted at `/workspace` when we start the container.
 
-If you would like to learn more about how our Docker integration works, we recommend to check out [Docker Integration](/learn/environment/docker).
+If you would like to learn more about how our Docker integration works, we recommend checking out [Docker Integration](/learn/environment/docker).
 
 ### Task Configuration
 
@@ -75,8 +92,8 @@ To create a task configuration, open the command palette by typing <kbd>⌘</kbd
 
 There are two fields in this file:
 
-- `setupTasks`: these tasks are run when the VM boots, or when a new commit comes in on a protected branch (like `main`)
-- `tasks`: these tasks are available through devtools, and are the recommended way to configure commands to start development servers or build tasks
+- `setupTasks`: these tasks are run when the VM boots or when a new commit comes in on a protected branch (like `main`).
+- `tasks`: these tasks are available through DevTools and are the recommended way of configuring commands to start development servers or build tasks.
 
 An example configuration could look like this:
 
@@ -112,31 +129,33 @@ An example configuration could look like this:
 
 This configuration says that:
 
-- We should run `pnpm install` during setup
-- We should run `pnpm dev:v2` when setup has completed
-  - In any case that `pnpm-lock.yaml` changes, restart this task
-  - When a new PR opens, make a deployment for port `4000` and put it in the pull request
-- There's a task available to run tests, which anyone can click to run tests
+- We should run `pnpm install` during setup.
+- We should run `pnpm dev:v2` when setup has been completed.
+  - In case `pnpm-lock.yaml` changes, restart this task.
+  - When a new PR opens, make a deployment for port `4000` and put it in the pull request.
+- There's a task available to run tests, which anyone can click to run tests.
 
-<Callout emoji="💡">There are more properties you can configure in this config, you can find more information about this [here](/learn/repositories/task#tasks-configuration).</Callout>
+<Callout emoji="💡">There are more properties you can configure in this config, you can find more information about this under [Task](/learn/repositories/task#tasks-configuration).</Callout>
 
 By making these changes, you'll ensure that the environment works by default. Other developers won't have to figure out what setup to do, or what commands to run to get started.
 
 <Callout emoji="⭐">Tasks are not started as your user, but by a global user named `pitcher-host`.</Callout>
 
-### Secret Configuration
+### Configuring Secrets
 
-Many repositories require some environment variables to be set. Either to connect to an external service, or as configuration of the environment itself.
+Several repositories require setting environment variables—either to connect to an external service or as the configuration of the environment itself.
 
-CodeSandbox allows you to set environment variables by clicking on our logo in the top left corner, and clicking on “Env variables”. These environment variables will be encrypted and stored in our database. After you've set the environment variables, they will be available for any branch in the repository after a restart.
+CodeSandbox allows you to set environment variables by clicking on our logo in the top left corner, and clicking on "Project Settings" and then “Env Variables”.
 
-You can learn more about our environment variable support [here](/learn/environment/secrets).
+These environment variables will be encrypted and stored in our database. After you've set the environment variables, they will be available for any branch in the repository after a restart.
+
+You can learn more about our environment variable support under [Secrets](/learn/environment/secrets).
 
 ### VS Code Configuration
 
-CodeSandbox supports opening branches in VS Code and in our native iOS app. When you open the branch inside VS Code, you will have access to your own extensions, keybindings and themes.
+CodeSandbox supports opening branches in [VS Code](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and in our [native iOS app](https://apps.apple.com/us/app/codesandbox/id1423330822). When you open the branch inside VS Code, you will have access to your own extensions, keybindings and themes.
 
-<Callout emoji="⭐">VS Code and iOS also have live collaboration. This means that you'll be able to work together with someone who has the same branch open inside the web editor.</Callout>
+<Callout emoji="⭐">VS Code and iOS also have live collaboration across different editors. This means that you'll be able to work together with someone who has the same branch open inside the web editor.</Callout>
 
 If you want to configure default VS Code extensions to be installed for your repository, you can create a new file called `.vscode/recommendations.json`.
 
@@ -150,7 +169,7 @@ This is an example of how this file could look like:
 
 When someone opens this VM in VS Code, we'll make sure that the extensions are preinstalled.
 
-If you want to have some personal extensions available in any CodeSandbox branch, you can update your own VS Code settings to reflect this. In your VS Code settings (we recommend opening the JSON version by clicking on the File icon in the top left), you can add these settings for example:
+If you want to have some personal extensions available in any CodeSandbox branch, you can update your own VS Code settings to reflect this. In your VS Code settings (we recommend opening the JSON version by clicking on the File icon in the top left), you can add these settings, for example, to automatically install these extensions when connecting to a VM:
 
 ```json
   "remote.SSH.defaultExtensions": [
@@ -162,17 +181,17 @@ If you want to have some personal extensions available in any CodeSandbox branch
   ]
 ```
 
-To automatically install these extensions when connecting with a VM.
-
 ### Deployment Previews & GitHub App
 
-Now that you've configured your repository to work in CodeSandbox, you can also configure deployment previews. This way, every PR will have a preloaded running development environment available for anyone on the team to use. This is great for reviewing changes, testing the application, or quickly making changes to a PR.
+Now that you've configured your repository to work in CodeSandbox, we highly recommend that you also configure deployment previews.
 
-To enable deployment previews, you need to install the GitHub App. You can do this through the command palette by opening the command palette (<kbd>⌘</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>) and selecting “Install GitHub App”.
+With deployment previews, CodeSandbox automatically adds a link to every PR you open, allowing anyone with access to the repo to open the PR on a preloaded development environment running in CodeSandbox. This is great for reviewing changes, testing the application, or quickly making changes to a PR.
 
-After you've gone through the steps of the installation, you should automatically get deployments for new PRs with a link to both the preview (if configured through tasks) and the development environment!
+To enable deployment previews, you need to install the CodeSandbox GitHub App. You can do this by opening the command palette (<kbd>⌘</kbd>/<kbd>Ctrl</kbd> + <kbd>Shift</kbd> + <kbd>P</kbd>) and selecting “Install GitHub App”.
 
-There are more advantages of using the GitHub App, like automatic dashboard syncing. You can learn more about this [here](/learn/integrations/github-app).
+After you've gone through the install steps, you should automatically get deployments for new PRs with a link to both the preview (if configured through tasks) and the development environment!
+
+There are more advantages to using the CodeSandbox GitHub App, like automatic dashboard syncing. You can learn more about this under [GitHub App](/learn/integrations/github-app).
 
 ## Troubleshooting
    
@@ -184,8 +203,7 @@ There are more advantages of using the GitHub App, like automatic dashboard sync
 You need to have `write` permission on GitHub to be able to import the project. Repositories where you only have `read` access can only be forked.
 
 - Verify your **GitHub permissions**. 
-CodeSandbox requires full git access to be able to import and commit. If you face any authentication errors, follow the steps to reset your GitHub permissions listed below.
-    
+CodeSandbox requires full git access to be able to import and commit. If you face any authentication errors, follow the steps listed below to reset your GitHub permissions.
     
 #### **Resetting GitHub permissions**
 


### PR DESCRIPTION
This PR adds a new section to the Repository Setup + Tips & Tricks page on the Docs to highlight how the branching workflow works—namely, to emphasize how we do seamless branching.

I also took the opportunity to do a grammar review of the whole page.

Closes CP-811