### PR TITLE
feat: synced template documentation & cli/api changes

### DIFF
--- a/packages/projects-docs/pages/learn/getting-started/your-first-sandbox.mdx
+++ b/packages/projects-docs/pages/learn/getting-started/your-first-sandbox.mdx
@@ -2,13 +2,15 @@
 title: Set up your first sandbox
 description: Learn how to take your first steps with CodeSandbox sandboxes.
 ---
+
 import { Callout } from 'nextra-theme-docs'
 import { Tabs, WrapContent } from '../../../../../shared-components/Tabs'
 
 # Getting Started with Sandboxes
+
 Sandboxes are a great way to get working on your idea with zero startup costs.
 
-CodeSandbox provides both [Cloud Sandboxes](/learn/sandboxes/overview?tab=cloud#what-is-a-cloud-sandbox) (powered by microVMs, so they're more powerful) and [Browser Sandboxes](/learn/sandboxes/overview) (powered by your browser, so they have more limits).
+CodeSandbox provides both [Cloud Sandboxes](/learn/sandboxes/overview?tab=cloud#what-is-a-cloud-sandbox) (powered by microVMs, so they're more powerful) and [Browser Sandboxes](/learn/sandboxes/overview) (powered by your browser, so they are more limited).
 
 All CodeSandbox sandboxes are fully [collaborative](/learn/getting-started/collaborate-share?tab=browser-sandboxes).
 
@@ -16,6 +18,7 @@ All CodeSandbox sandboxes are fully [collaborative](/learn/getting-started/colla
     <WrapContent>
 
 ## Using Cloud Templates
+
 Cloud Sandboxes are an all-around great solution to help you prototype any app, regardless of the language you're using or the complexity of your project.
 
 They have built-in [Docker support](/learn/environment/docker) and include several valuable features, such as collaborative [Terminals](/learn/repositories/terminal), [Tasks](/learn/repositories/task), and [VS Code integration](/learn/getting-started/setting-up-vscode).
@@ -25,7 +28,7 @@ Cloud sandboxes are built for scale. Our Free plan includes generous VM specs bu
 </Callout>
 
 One of the best things about our Cloud Sandboxes is that there are dozens of official templates you can use to start coding.
-    
+
 To get started, [open the `New` Modal](https://codesandbox.io/s/) and search through our selection of Cloud Sandbox Templates. You can recognize a Cloud Sandbox by the special _Cloud_ badge.
 
 Templates are automatically forked when you select them, so you can edit
@@ -33,24 +36,6 @@ and begin creating your own sandbox.
 
 <br/> 
 ![Cloud Sandbox Templates](../images/dashboard-cloud-template.jpg)
-
-## Opening a GitHub Repository as a Cloud Sandbox
-
-Typically, whenever you want to run a GitHub repository in CodeSandbox, we recommend that you [import it](/learn/getting-started/setting-up-repository#create-a-team--import-a-repository) as a CodeSandbox Repository.
-
-However, there are some cases where you might want to run a given repository (or a specific sub-folder of that repo) as a Cloud Sandbox. This is especially handy for large monorepos that include an `/examples` subfolder.
-
-As an example, let's consider the [Blog example](https://github.com/withastro/astro/tree/main/examples/blog) from the official Astro repository.
-
-To easily run it as a Cloud Sandbox that's synced to the GitHub repo, simply update the URL in the address bar from:
-
-`https://github.com/withastro/astro/tree/main/examples/blog`
-
-To:
-
-`https://codesandbox.io/p/sandbox/github/withastro/astro/tree/main/examples/blog`
-
-Then, you can easily fork that synced Cloud Sandbox and start prototyping.
 
 ## Growing a Cloud Sandbox into a Repository
 
@@ -64,10 +49,11 @@ You can scale your Cloud Sandbox into a Repository by navigating to the git menu
 
 ## Programmatically creating Cloud Sandboxes
 
-If you want to use our API to create Cloud Sandboxes, refer to our [Define API](/learn/getting-started/your-first-sandbox?tab=browser#define-api) documentation and be sure to add an additional `environment: "server"` parameter to the request body.
- 
+If you want to use our API to create Cloud Sandboxes, refer to our [Define API](/learn/sandboxes/cli-api#define-api) documentation and be sure to add an additional `environment: "server"` parameter to the request body.
+
     </WrapContent>
     <WrapContent>
+
 ## Finding Browser Sandbox Templates
 
 The most popular way of creating a new Sandbox is the 'New' modal.
@@ -78,303 +64,9 @@ The **`New`** modal shows you collections of templates grouped first by relevanc
 
 Templates are automatically forked when you select them, so you can edit
 and begin creating your own sandbox.
-<br/>
-
-### Using GitHubBox.com
-
-An easy way to import a repo to CodeSandbox as a browser sandbox via URL is with GitHubBox.com.
-Append 'box' to your github.com URL in between 'hub' and '.com' and it will
-redirect to CodeSandbox.
-
-Here's an example:
-
-Change the GitHub URL:
-
-`https://github.com/reduxjs/redux/tree/master/examples/todomvc`
-
-To:
-
-`https://githubbox.com/reduxjs/redux/tree/master/examples/todomvc`
-
-The result is we take the last part of the URL (everything after github.com) and
-use it in our importer at `codesandbox.io/s/github/`, adding the repo to
-CodeSandbox.
-
-<Callout>
-Unless you specifically want to use a Browser Sandbox, we recommend that you skip this method and instead import a GitHub repo as a [CodeSandbox Repository](/learn/getting-started/setting-up-repository#create-a-team--import-a-repository) or a [synced Cloud Sandbox](/learn/getting-started/your-first-sandbox#opening-a-github-repository-as-a-cloud-sandbox).
-</Callout>
 
 <br/>
 
-### Using a Browser Extension
-
-We have browser extensions for
-[Chrome](https://chrome.google.com/webstore/detail/open-in-codesandbox/hdidglkcgdolpoijdckmafdnddjoglia)
-and [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/codesandbox/),
-which add an 'Open in CodeSandbox' button to GitHub repo pages. This makes it
-easy to import existing projects from GitHub in to CodeSandbox.
-
-<br/>
-### Setting inference
-
-When importing, we infer sandbox settings based on several files in a
-repository.
-
-| Sandbox Setting | Inferred from                                                                                                                                         |
-| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Title           | `name` field in `package.json`                                                                                                                        |
-| Description     | `description` field in `package.json`                                                                                                                 |
-| Tags            | `keywords` field in `package.json`                                                                                                                    |
-| Template        | Based on [this](https://github.com/codesandbox-app/codesandbox-importers/blob/master/packages/import-utils/src/create-sandbox/templates.ts#L63) logic |
-
-If the correct template isn't automatically being used when importing, then you
-may specify a `template` property in your `./sandbox.config.json` file to
-override the detected template.
-
-```json
-{
-  "template": "node"
-}
-```
-<br/>
-
-## Import Local projects via CLI
-
-You can import a local project into CodeSandbox by using our
-[CLI](https://github.com/codesandbox-app/codesandbox-importers/tree/master/packages/cli).
-
-To install our CLI, run `npm install -g codesandbox`. Then import a
-project by running `codesandbox {directory}`.
-<br/>
-
-### Example usage
-
-```
-$ npm install -g codesandbox
-$ codesandbox ./
-```
-<br/>
-
-## Define API
-
-We offer an API that allows you to programmatically create a sandbox. This is
-useful for documentation, enabling you to generate a sandbox on the fly from
-code examples. You can call the endpoint
-`https://codesandbox.io/api/v1/sandboxes/define` both with a `GET` and with a
-`POST` request.
-<br/>
-
-### Supported Parameters
-
-We currently support three extra parameters. The query accepts the same options
-as the [embed options](/learn/sandboxes/embedding).
-
-| Query Parameter | Description                                                                           | Example Input               |
-| --------------- | ------------------------------------------------------------------------------------- | --------------------------- |
-| `parameters`    | Parameters used to define how the sandbox should be created.                          | Example below               |
-| `query`         | The query that will be used in the redirect URL.                                      | `view=preview&runonclick=1` |
-| `embed`         | Defines whether we should redirect to the embed instead of the editor.                        | `1`                         |
-| `json`          | Instead of redirecting we will send a JSON response with `{"sandbox_id": sandboxId}`. | `1`                         |
-<br/>
-
-### How it works
-
-The API only needs one argument: `files`. This argument contains the files that
-will be contained in the sandbox.
-
-An example body would be:
-
-```json
-{
-  "files": {
-    "index.js": {
-      "content": "console.log('hello!')",
-      "isBinary": false
-    },
-    "package.json": {
-      "content": {
-        "dependencies": {}
-      }
-    }
-  }
-}
-```
-
-#### Binary Files
-
-You can import binary files by setting `isBinary` to `true` and `content` as a
-URL to the file hosted externally. For example:
-
-```json
-{
-  "isBinary": true,
-  "content": "https://..."
-}
-```
-<br/>
-
-#### Folders
-
-You can create folders by naming the file with a `/` in its name, allowing you to
-structure your application as you prefer:
-
-```json
-{
-  "files": {
-    "src/index.js": {
-      "content": "console.log('hello!')",
-      "isBinary": false
-    },
-    "package.json": {
-      "content": {
-        "dependencies": {}
-      }
-    }
-  }
-}
-```
-
-This will create a file called `index.js` in your `src` folder.
-<br/>
-
-#### Package.json
-
-Every request **requires** a `package.json`. This file can either be a string or
-an object. We determine all of the sandbox's information from the files, like we
-do with the GitHub import.
-<br/>
-
-### GET Request
-
-It's quite difficult to send the JSON parameters with a GET request. There is a chance
-of unescaped characters and the URL hits its limit of ~2000 characters quickly.
-That's why we first compress the files to a compressed `lz-string`. We offer a
-utility function in the `codesandbox` dependency for this. The implementation
-looks like this:
-
-```js
-import { getParameters } from 'codesandbox/lib/api/define';
-
-const parameters = getParameters({
-  files: {
-    'index.js': {
-      content: "console.log('hello')",
-    },
-    'package.json': {
-      content: { dependencies: {} },
-    },
-  },
-});
-
-const url = `https://codesandbox.io/api/v1/sandboxes/define?parameters=${parameters}`;
-```
-<br/>
-
-#### Example Sandbox
-
-`https://codesandbox.io/s/6yznjvl7nw?editorsize=50&fontsize=14&hidenavigation=1&runonclick=1`
-<br/>
-
-### POST Form
-
-You can do the exact same steps for a POST request, but instead of a URL, you'd
-show a form. With a POST request, you can create bigger sandboxes.
-<br/>
-
-#### Example Sandbox
-
-`https://codesandbox.io/s/qzlp7nw34q?editorsize=70&fontsize=14&hidenavigation=1&runonclick=1`
-<br/>
-
-### Define without render
-
-If you want to define a new sandbox without getting it rendered, you can add
-`?json=1` to the request. For instance,
-`https://codesandbox.io/api/v1/sandboxes/define?json=1`. Instead of the render,
-the result will be JSON data providing you with the `sandbox_id` of the new
-sandbox.
-
-This is useful, for instance, if you need to create a new sandbox
-programmatically, so you can then embed it on your site (see
-[Embed documentation](/learn/sandboxes/embedding)).
-
-Both `GET` and `POST` requests are supported.
-<br/>
-
-### XHR Request
-
-You can also create a sandbox using an XHR request, like using `fetch`. An
-example sandbox is:
-
-`https://codesandbox.io/s/9loovqj5oy?editorsize=70&fontsize=14&hidenavigation=1&runonclick=1`
-<br/>
-
-## Import Single Components
-
-You can import a local component into CodeSandbox by using our other
-[CLI](https://github.com/codesandbox/codesandboxer/tree/master/packages/codesandboxer-fs).
-
-You can install our CLI by running `npm install -g codesandboxer-fs`. Then you
-can export a project by running `codesandboxer {filePath}`.
-
-```
-$ npm install -g codesandboxer-fs
-$ codesandboxer docs/examples/my-single-component.js
-```
-
-This will print out the ID of a sandbox that does nothing but render the
-targeted component, along with a link to that sandbox. This will also bundle in
-other local files used by the component to ensure render.
-<br/>
-
-## Import Using Codesandboxer
-
-[Codesandboxer](https://github.com/codesandbox/codesandboxer) imports a single
-file from a git repository, along with supplemental files and dependencies.
-
-Using this creates an easy way to upload an example instead of an entire git
-repository. This enables you to easily share examples with others, or to link to
-editable versions of examples from a documentation website. React-codesandboxer
-is the main version, but there are also versions for VS Code, Atom, and
-BitBucket.
-<br/>
-
-### How it works
-
-Below the surface, `react-codesandboxer` fetches the files it needs from GitHub or
-BitBucket, using a single file that will be rendered as the 'example' as an
-entry point, then uses the Define API to upload the necessary files into a new
-`create-react-app` sandbox.
-
-Check out the [codesandboxer docs](https://github.com/codesandbox/codesandboxer)
-for information on how to implement it.
-
-```jsx harmony
-import React, { Component } from 'react';
-import CodeSandboxer from 'react-codesandboxer';
-
-export default () => (
-  <CodeSandboxer
-    examplePath="examples/file.js"
-    gitInfo={{
-      account: 'noviny',
-      repository: 'react-codesandboxer',
-      host: 'github',
-    }}
-  >
-    {() => <button type="submit">Upload to CodeSandbox</button>}
-  </CodeSandboxer>
-);
-```
-<br/>
-
-## Import Using Remark-codesandbox
-
-[Remark-codesandbox](https://github.com/kevin940726/remark-codesandbox) is a
-remark plugin for creating sandboxes directly from code blocks in documentation.
-Developed by CodeSandbox community member Kai Hao, it supports popular platforms
-including MDX, Gatsby, Storybook Docs, docz etc. Learn more about it in their
-[documentation](https://github.com/kevin940726/remark-codesandbox#remark-codesandbox).
-       
     </WrapContent>
+
 </Tabs>

--- a/packages/projects-docs/pages/learn/sandboxes/_meta.json
+++ b/packages/projects-docs/pages/learn/sandboxes/_meta.json
@@ -6,6 +6,8 @@
   "secrets": "Secrets",
   "configuration": "Configuration",
   "templates": "Templates",
+  "synced-templates": "Synced Templates",
+  "cli-api": "Sandbox CLI & API",
   "deployment": "Deployment Options",
   "custom-npm-registry": "Custom NPM Registry",
   "ci": "CodeSandbox CI"

--- a/packages/projects-docs/pages/learn/sandboxes/cli-api.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/cli-api.mdx
@@ -1,0 +1,259 @@
+---
+title: Create Sandboxes with the CLI & API
+authors: ['CompuIves']
+description: Learn how to create sandboxes with the API and CLI
+---
+
+# Create Sandboxes with the CLI & API
+
+There are multiple ways to create sandboxes programmatically. In [Synced Templates](https://codesandbox.io/docs/learn/sandboxes/synced-templates) we describe how to create sandboxes from a GitHub repository or folder. This guide will show you how to create sandboxes using the CLI & API.
+
+## CodeSandbox CLI
+
+You can import a local project into CodeSandbox by using our
+[CLI](https://github.com/codesandbox-app/codesandbox-importers/tree/master/packages/cli).
+
+To install our CLI, run `npm install -g codesandbox`. Then import a
+project by running `codesandbox {directory}`.
+
+### Example usage
+
+```
+$ npm install -g codesandbox
+$ codesandbox ./
+```
+
+## Define API
+
+We offer an API that allows you to programmatically create a sandbox. This is
+useful for documentation, enabling you to generate a sandbox on the fly from
+code examples. You can call the endpoint
+`https://codesandbox.io/api/v1/sandboxes/define` both with a `GET` and with a
+`POST` request.
+
+### Supported Parameters
+
+We currently support three extra parameters. The query accepts the same options
+as the [embed options](/learn/sandboxes/embedding).
+
+| Query Parameter | Description                                                                           | Example Input               |
+| --------------- | ------------------------------------------------------------------------------------- | --------------------------- |
+| `parameters`    | Parameters used to define how the sandbox should be created.                          | Example below               |
+| `query`         | The query that will be used in the redirect URL.                                      | `view=preview&runonclick=1` |
+| `embed`         | Defines whether we should redirect to the embed instead of the editor.                | `1`                         |
+| `json`          | Instead of redirecting we will send a JSON response with `{"sandbox_id": sandboxId}`. | `1`                         |
+
+### How it works
+
+The API only needs one argument: `files`. This argument contains the files that
+will be contained in the sandbox.
+
+An example body would be:
+
+```json
+{
+  "files": {
+    "index.js": {
+      "content": "console.log('hello!')",
+      "isBinary": false
+    },
+    "package.json": {
+      "content": {
+        "dependencies": {}
+      }
+    }
+  }
+}
+```
+
+#### Binary Files
+
+You can import binary files by setting `isBinary` to `true` and `content` as a
+URL to the file hosted externally. For example:
+
+```json
+{
+  "isBinary": true,
+  "content": "https://..."
+}
+```
+
+#### Folders
+
+You can create folders by naming the file with a `/` in its name, allowing you to
+structure your application as you prefer:
+
+```json
+{
+  "files": {
+    "src/index.js": {
+      "content": "console.log('hello!')",
+      "isBinary": false
+    },
+    "package.json": {
+      "content": {
+        "dependencies": {}
+      }
+    }
+  }
+}
+```
+
+This will create a file called `index.js` in your `src` folder.
+
+### GET Request
+
+It's quite difficult to send the JSON parameters with a GET request. There is a chance
+of unescaped characters and the URL hits its limit of ~2000 characters quickly.
+That's why we first compress the files to a compressed `lz-string`. We offer a
+utility function in the `codesandbox` dependency for this. The implementation
+looks like this:
+
+```js
+import { getParameters } from 'codesandbox/lib/api/define';
+
+const parameters = getParameters({
+  files: {
+    'index.js': {
+      content: "console.log('hello')",
+    },
+    'package.json': {
+      content: { dependencies: {} },
+    },
+  },
+});
+
+const url = `https://codesandbox.io/api/v1/sandboxes/define?parameters=${parameters}`;
+```
+
+<br/>
+<iframe
+    src="https://codesandbox.io/embed/6yznjvl7nw?editorsize=50&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
+    width="100%"
+    height="500px"
+    style={{border: 0, borderRadius: 4, outline:'none'}}
+    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+### POST Form
+
+You can do the exact same steps for a POST request, but instead of a URL, you'd
+show a form. With a POST request, you can create bigger sandboxes.
+
+<br/>
+<iframe
+    src="https://codesandbox.io/embed/qzlp7nw34q?editorsize=50&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
+    width="100%"
+    height="500px"
+    style={{border: 0, borderRadius: 4, outline:'none'}}
+    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+### Define without render
+
+If you want to define a new sandbox without getting it rendered, you can add
+`?json=1` to the request. For instance,
+`https://codesandbox.io/api/v1/sandboxes/define?json=1`. Instead of the render,
+the result will be JSON data providing you with the `sandbox_id` of the new
+sandbox.
+
+This is useful, for instance, if you need to create a new sandbox
+programmatically, so you can then embed it on your site (see
+[Embed documentation](/learn/sandboxes/embedding)).
+
+Both `GET` and `POST` requests are supported.
+
+### XHR Request
+
+You can also create a sandbox using an XHR request, like using `fetch`. An
+example sandbox is:
+
+<br/>
+<iframe
+    src="https://codesandbox.io/embed/9loovqj5oy?editorsize=50&fontsize=14&hidedevtools=1&hidenavigation=1&runonclick=1"
+    width="100%"
+    height="500px"
+    style={{border: 0, borderRadius: 4, outline:'none'}}
+    allow="accelerometer; ambient-light-sensor; camera; encrypted-media; geolocation; gyroscope; hid; microphone; midi; payment; usb; vr; xr-spatial-tracking"
+    sandbox="allow-forms allow-modals allow-popups allow-presentation allow-same-origin allow-scripts"
+></iframe>
+
+## Import Single Components
+
+You can import a local component into CodeSandbox by using our other
+[CLI](https://github.com/codesandbox/codesandboxer/tree/master/packages/codesandboxer-fs).
+
+You can install our CLI by running `npm install -g codesandboxer-fs`. Then you
+can export a project by running `codesandboxer {filePath}`.
+
+```
+$ npm install -g codesandboxer-fs
+$ codesandboxer docs/examples/my-single-component.js
+```
+
+This will print out the ID of a sandbox that does nothing but render the
+targeted component, along with a link to that sandbox. This will also bundle in
+other local files used by the component to ensure render.
+
+## Import Using Codesandboxer
+
+[Codesandboxer](https://github.com/codesandbox/codesandboxer) imports a single
+file from a git repository, along with supplemental files and dependencies.
+
+Using this creates an easy way to upload an example instead of an entire git
+repository. This enables you to easily share examples with others, or to link to
+editable versions of examples from a documentation website. React-codesandboxer
+is the main version, but there are also versions for VS Code, Atom, and
+BitBucket.
+
+### How it works
+
+Below the surface, `react-codesandboxer` fetches the files it needs from GitHub or
+BitBucket, using a single file that will be rendered as the 'example' as an
+entry point, then uses the Define API to upload the necessary files into a new
+`create-react-app` sandbox.
+
+Check out the [codesandboxer docs](https://github.com/codesandbox/codesandboxer)
+for information on how to implement it.
+
+```jsx harmony
+import React, { Component } from 'react';
+import CodeSandboxer from 'react-codesandboxer';
+
+export default () => (
+  <CodeSandboxer
+    examplePath="examples/file.js"
+    gitInfo={{
+      account: 'noviny',
+      repository: 'react-codesandboxer',
+      host: 'github',
+    }}
+  >
+    {() => <button type="submit">Upload to CodeSandbox</button>}
+  </CodeSandboxer>
+);
+```
+
+## Import Using Remark-codesandbox
+
+[Remark-codesandbox](https://github.com/kevin940726/remark-codesandbox) is a
+remark plugin for creating sandboxes directly from code blocks in documentation.
+Developed by CodeSandbox community member Kai Hao, it supports popular platforms
+including MDX, Gatsby, Storybook Docs, docz etc. Learn more about it in their
+[documentation](https://github.com/kevin940726/remark-codesandbox#remark-codesandbox).
+
+## Sandbox information inference
+
+When importing, we infer sandbox settings based on several files in a
+repository.
+
+| Sandbox Setting | Inferred from                                                                                                                                         |
+| --------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Title           | `name` field in `package.json`                                                                                                                        |
+| Description     | `description` field in `package.json`                                                                                                                 |
+| Tags            | `keywords` field in `package.json`                                                                                                                    |
+| Template        | Based on [this](https://github.com/codesandbox-app/codesandbox-importers/blob/master/packages/import-utils/src/create-sandbox/templates.ts#L63) logic |
+
+If you want to override any of these settings, you can create a `template.json` in the `.codesandbox` folder. You can find more info about this setting [here](https://codesandbox.io/docs/learn/sandboxes/synced-templates#configuring-a-title-icon--description).

--- a/packages/projects-docs/pages/learn/sandboxes/overview.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/overview.mdx
@@ -10,47 +10,41 @@ import { Tabs, WrapContent } from '../../../../../shared-components/Tabs'
 Sandboxes are the environment for rapid web development.
 
 <Tabs tabs={["Browser", "Cloud"]}>
-    <WrapContent>
+<WrapContent>
     ## What is a Browser Sandbox?
       When using Browser Sandboxes, your code is evaluated and run in our built-in
 execution environment. These client environments run entirely inside of your browser and will continue to
-bundle your code even when you lose your connection to our servers. 
+bundle your code even when you lose your connection to our servers.
 
 Browser Sandboxes each have their own bundler attached to them which are
 configured to support a specific framework and emulate their official CLI tools.
 They are not one-to-one implementations and thus do not support advanced
 configuration like custom webpack configurations or ejecting. However, they are
-designed to mirror the default behavior of the framework. 
+designed to mirror the default behavior of the framework.
 
 If your project requires the use of a terminal or any additional advanced configuration like Docker, you can use a [Cloud Sandbox](/learn/sandboxes/overview?tab=cloud) instead.
-    </WrapContent>
-    <WrapContent>
-       ## What is a Cloud Sandbox?
-       Unlike Browser Sandboxes that run on your browser, Cloud Sandboxes run on our [microVMs](/learn/environment/vm).
-       
+
+</WrapContent>
+<WrapContent> 
+## What is a Cloud Sandbox?
+Unlike Browser Sandboxes that run on your browser, Cloud Sandboxes run on our [microVMs](/learn/environment/vm).
+
        Cloud Sandboxes are great for any prototyping needs and are suitable for any type of project. They can run both backend and frontend services.
        You can learn more about the editor and the unique functionalities of the cloud developer environment in [Repositories](/learn/repositories/overview).
-       
+
        Like Browser Sandboxes, Cloud Sandboxes are free to use.
-       
+
        Cloud Sandboxes run on microVMs, which brings two features that make them great for prototyping:
-       
+
        1. Fast cloning. You can fork a sandbox [within 2 seconds](https://codesandbox.io/blog/how-we-clone-a-running-vm-in-2-seconds) and continue with an exact clone of the microVM. This way, you can quickly test multiple approaches to your prototype.
        2. Instant resume. When you connect to a Cloud Sandbox, it will wake up within 1 second and continue with your running dev server. This way, you can quickly continue prototyping.
-       
+
        Cloud Sandboxes and Repositories run on the same infrastructure and use the same editor. The main distinction between the two is that Sandboxes are built for prototyping while Repositories are built for full-scale development. Once you scale a Sandbox to a Repository, you will have:
        - Branching
-       - Git tooling 
+       - Git tooling
        - Full integration with GitHub
-       
-        ## Create a sandbox from GitHub subfolder or branch
-        
-        Synced Sandboxes are the easiest way to make running and shareable sandboxes from GitHub subfolders, branches or repositories. 
-        
-        These sandboxes stay updated with any changes made to GitHub and are ideal for examples, tutorials or templates as users can fork and start a new project from them. 
 
-        To create a new sandbox from GitHub, change the GitHub url to `https://codesandbox.io/p/sandbox/github` + `/path/`.
-        
-        For example, here's a link to an Astro example sandbox from a subfolder -  https://codesandbox.io/p/sandbox/github/withastro/astro/main/examples/blog.
+       To configure a Cloud Sandbox, you can read more about it [tasks](https://codesandbox.io/docs/learn/repositories/task) and [Docker](https://codesandbox.io/docs/learn/environment/docker).
     </WrapContent>
+
 </Tabs>

--- a/packages/projects-docs/pages/learn/sandboxes/synced-templates.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/synced-templates.mdx
@@ -1,0 +1,88 @@
+---
+title: Synced Templates
+authors: ['CompuIves']
+description: With synced templates you can create a template from a GitHub repository that stays in sync with its source
+---
+
+import { Callout } from 'nextra-theme-docs'
+
+# Synced Templates
+
+## What are synced templates?
+
+Synced templates are [templates](https://codesandbox.io/docs/learn/sandboxes/templates) that are created from a GitHub repository, or a folder in a GitHub repository. A synced template stays in sync with its source, so when you create a commit in the GitHub repository, the template will automatically update on next access with the new contents.
+
+<Callout>
+  Because synced templates stay in sync with its source, you can't edit a synced template in CodeSandbox. If you want to edit the template, you'll have to commit to the source repository. You could consider that GitHub is the "owner" of the template.
+</Callout>
+
+### How is a synced template different from CodeSandbox Repositories?
+
+CodeSandbox also has [Repositories](https://codesandbox.io/docs/learn/repositories/overview), which are also imported from GitHub repositories. However, there is a key difference between synced templates and repositories.
+
+Repositories are meant for working on a repository. We introduce a workflow to create new branches and pull requests. Synced templates are meant to create a sandbox template from a repository (or folder), and are meant for using as template for new sandboxes (or for sharing as example with others).
+
+A good rule of thumb is that if you want to work on a repository, you should import a repository. If you want to create a template from a repository, you should create a synced template from a GitHub repository.
+
+## Creating a synced template
+
+A synced template URL is essentially the same as the GitHub URL, but `github.com` is replaced with `codesandbox.io/s/github`. Because of this, you can go to your GitHub repository, and replace `github.com` with `codesandbox.io/s/github` to create a synced template. We have also introduced three helpers to do this more easily:
+
+https://codesandbox.io/s/github/withastro/astro/main/examples/blog
+
+### Directly from the GitHub URL
+
+First, visit the GitHub repository or folder that you want to create a synced template from. The URL should look something like `https://github.com/owner/repo` for a repository, and it should look like `https://github.com/owner/repo/tree/main/folder` for a folder.
+
+Then, replace `github.com` with `githubbox.com` and press Enter.
+
+This will redirect you to a URL that looks like `https://codesandbox.io/s/github/owner/repo` or `https://codesandbox.io/s/github/owner/repo/tree/main/folder`, which is the location of the newly created synced template!
+
+### Using our GitHub importer
+
+Go to our ["New Sandbox" modal](https://codesandbox.io/s) and click on the "Import template" button. Enter the GitHub URL you want to import in the input field and press "Open URL". This will redirect you to the location of the synced template.
+
+### Using a Browser Extension
+
+We have browser extensions for
+[Chrome](https://chrome.google.com/webstore/detail/open-in-codesandbox/hdidglkcgdolpoijdckmafdnddjoglia)
+and [Firefox](https://addons.mozilla.org/en-GB/firefox/addon/codesandbox/),
+which add an 'Open in CodeSandbox' button to GitHub repo pages. This makes it
+easy to import existing projects from GitHub in to CodeSandbox.
+
+## Configuring a title, icon & description
+
+By default, we try to infer the name, description and icon of a synced template based on the files in the repository. However, you can also configure this manually.
+
+You can configure a title, description and template icon for your synced template in a file called `.codesandbox/template.json` in your synced template. This file is a JSON file that contains the following properties:
+
+- `title`: The title of the template
+- `description`: The description of the template
+- `iconUrl`: The icon of the template. This should be a URL to a 64x64 PNG or JPEG image.
+- `tags`: The tags that will be used for search results. This should be an array of strings.
+- `published`: Whether the template is published. If this is set to `false`, the template will not be visible in the template search.
+
+An example `template.json` could look like this:
+
+```jsonc
+// .codesandbox/template.json
+{
+  "title": "My Template",
+  "description": "This is my template",
+  "iconUrl": "https://example.com/icon.png",
+  "tags": ["react", "typescript"],
+  "published": true
+}
+```
+
+All fields are optional, we will infer the missing fields from the repository contents.
+
+After you've created this file, and opened the synced template at least once, you can find it in the [template search](https://codesandbox.io/s) by searching for the title or description.
+
+## VM behaviour of synced templates
+
+For our [cloud sandboxes](https://codesandbox.io/docs/learn/sandboxes/overview?tab=cloud), we run your sandbox in a microVM. We try to automatically detect from your repository contents whether your project is more suited for a cloud sandbox than a browser sandbox. To force the template to load as a cloud sandbox, you can create a `.codesandbox/Dockerfile` file in your repository. This file should contain a valid Dockerfile that we'll use to build your cloud sandbox.
+
+We use memory snapshotting to resume a VM quickly when someone visits it. To ensure that visitors of your sandbox will always get the latest contents of your GitHub repository, we base the memory snapshot on the latest commit of your repository or folder.
+
+This means that if you create a new commit in your repository, we will discard the memory snapshot of the synced template and will start the sandbox from scratch on next visit. During boot of the VM, we will download the latest file contents from the repository. This ensures that visitors of your sandbox will always get the latest contents of your GitHub repository, but it also means that the first visit of your sandbox after a commit can be slower than usual (only for memory, we do still keep the filesystem between invalidations).

--- a/packages/projects-docs/pages/learn/sandboxes/templates.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/templates.mdx
@@ -8,13 +8,13 @@ description: Use templates to kickstart new projects with no setup.
 
 ## What are Templates?
 
-Templates are project starting points. They're already set up with the
+Templates are starting points for sandboxes. Sandboxes are forked from them. They're already set up with the
 configuration, file structure, and dependencies installed, so you don't have to
 spend time doing this each time you begin working on something new. Templates
 are easily accessible from your dashboard and the "New" modal.
 
 CodeSandbox has a number of official templates, such as React, Vue, Angular,
-Gatsby, and others that you can use to quickly start a new project.
+Gatsby, and others that you can use to quickly start a new project. You can find templates in the "Create New Sandbox" modal [here](https://codesandbox.io/s).
 
 You can also create your own custom templates. Turn any sandbox into a template
 that's customized for your particular use-case and preferences. Once a custom


### PR DESCRIPTION
This is a pretty big docs change. We introduce a new item for "Synced Templates" (templates created from GitHub) and add a new dedicated section for the CodeSandbox CLI and API, as they were not very discoverable (even not through search, for some reason), also the google results for CodeSandbox API are not there anymore. They need their own page.