### PR TITLE
docs(sandboxes): prioritize information on cloud sandboxes

### DIFF
--- a/packages/projects-docs/pages/learn/sandboxes/overview.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/overview.mdx
@@ -4,36 +4,26 @@ description: Learn about the differences between cloud sandboxes and browser san
 ---
 
 import { Tabs, WrapContent } from '../../../../../shared-components/Tabs'
+import { Callout } from 'nextra-theme-docs'
 
 # CodeSandbox Sandboxes
 
-Sandboxes are the ideal environment for rapid web development. CodeSandbox provides two types of sandboxes: browser sandboxes (which run in the browser) and cloud sandboxes (which run in a microVM).
+Sandboxes are the ideal environment for rapid web development. CodeSandbox provides two types of sandboxes: cloud sandboxes (which run in a microVM) and browser sandboxes (which run using browser resources).
 
 To create a new sandbox, you can clone a template from our ["Create Sandbox"](https://codesandbox.io/s) modal. When clicking on a template, we create a fork (a copy) of the template and open the newly created sandbox in our web editor.
 
-## Difference between Browser & Cloud Sandboxes
+<Callout>
+By default, we recommend using cloud sandboxes, which provide all the tooling needed for building prototypes. Browser sandboxes are mostly useful as a playground for basic front-end JavaScript projects.
+</Callout>
 
-<Tabs tabs={["Browser", "Cloud"]}>
-<WrapContent>
-    ## What is a Browser Sandbox?
-      When using Browser Sandboxes, your code is evaluated and run in our built-in
-execution environment. These client environments run entirely inside of your browser and will continue to
-bundle your code even when you lose your connection to our servers.
+## Difference between Cloud & Browser Sandboxes
 
-Browser Sandboxes each have their own bundler attached to them which is
-configured to support a specific framework and emulate their official CLI tools.
-They are not one-to-one implementations and thus do not support advanced
-configuration like custom webpack configurations or ejecting. However, they are
-designed to mirror the default behavior of the framework.
-
-If your project requires the use of a terminal or any additional advanced configuration like Docker, you can use a [Cloud Sandbox](/learn/sandboxes/overview?tab=cloud) instead.
-
-</WrapContent>
+<Tabs tabs={["Cloud", "Browser"]}>
 <WrapContent> 
 ## What is a Cloud Sandbox?
 Unlike Browser Sandboxes that run on your browser, Cloud Sandboxes run on our [microVMs](/learn/environment/vm).
 
-       Cloud Sandboxes are great for prototyping any type of project. They can run both backend and frontend services.
+       Cloud Sandboxes are great for prototyping any type of project. They can run both backend and front-end services.
        You can learn more about the editor and the unique functionalities of the cloud developer environment in [Repositories](/learn/repositories/overview).
 
        Like Browser Sandboxes, Cloud Sandboxes are free to use.
@@ -50,5 +40,20 @@ Unlike Browser Sandboxes that run on your browser, Cloud Sandboxes run on our [m
 
        To configure a Cloud Sandbox, you can read more about [tasks](https://codesandbox.io/docs/learn/repositories/task) and [Docker](https://codesandbox.io/docs/learn/environment/docker).
     </WrapContent>
+<WrapContent>
+    ## What is a Browser Sandbox?
+      When using Browser Sandboxes, your code is evaluated and run in our built-in
+execution environment. These client environments run entirely inside of your browser and will continue to
+bundle your code even when you lose your connection to our servers.
+
+Browser Sandboxes each have their own bundler attached to them which is
+configured to support a specific framework and emulate their official CLI tools.
+They are not one-to-one implementations and thus do not support advanced
+configuration like custom webpack configurations or ejecting. However, they are
+designed to mirror the default behavior of the framework.
+
+If your project requires the use of a terminal or any additional advanced configuration like Docker, you can use a [Cloud Sandbox](/learn/sandboxes/overview?tab=cloud) instead.
+
+</WrapContent>
 
 </Tabs>


### PR DESCRIPTION
This PR updates the "Overview" page under "Sandboxes" to focus on Cloud Sandboxes by default.

It also adds a callout to highlight we recommend using cloud sandboxes in most cases.