### PR TITLE
fix(Sandboxes): remove broken navigation references

### DIFF
--- a/packages/projects-docs/pages/learn/sandboxes/_meta.json
+++ b/packages/projects-docs/pages/learn/sandboxes/_meta.json
@@ -6,13 +6,8 @@
     "title": "Secrets",
     "href": "/learn/environment/secrets"
   },
-  "configuration": {
-    "title": "Configuration",
-    "href": "/learn/environment/secrets"
-  },
   "templates": "Templates",
   "synced-templates": "Synced Templates",
   "cli-api": "Sandbox CLI & API",
-  "deployment": "Deployment Options",
   "custom-npm-registry": "Custom NPM Registry"
 }


### PR DESCRIPTION
This PR fixes two broken navigation links under "Sandboxes".
- [Configuration](https://codesandbox.io/docs/learn/environment/secrets) is pointing to Secrets, so it seems like a duplicate.
- Deployment Options seems to be an empty reference.