### PR TITLE
docs(npm): fix typo in "custom registry" page

### DIFF
--- a/packages/projects-docs/pages/learn/sandboxes/custom-npm-registry.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/custom-npm-registry.mdx
@@ -107,7 +107,7 @@ We want to prevent this from accidentally happening, which is why we only allow
 private sandboxes to have access to the private registry. If you do want to
 share a public sandbox containing a private package, you can add the `.tgz` to
 the sandbox and link to it from the `package.json` by referring to it as
-`file:/package-tar-name.tgz` in the version field.
+`file:package-tar-name.tgz` in the version field.
 
 ### Our npm registry is behind a VPN, what can I do?
 


### PR DESCRIPTION
the workaround with using `file` has a leading slash, but that's not needed