### PR TITLE
Docs: small typo fix in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This repository is hosting all product documentation pages of CodeSandbox.
 
 ## About this repository
 
-The Projects is leveraging [Nextra](https://nextra.vercel.app/), which explains a lot of how the individual projects run. So we recommend checking it out to get a good understanding of the structure of this repository.
+The Project is leveraging [Nextra](https://nextra.vercel.app/), which explains a lot of how the individual projects run. So we recommend checking it out to get a good understanding of the structure of this repository.
 
 The individual documentations can be found in the
 - `packages`


### PR DESCRIPTION
I noticed this line "The Projects is leveraging [Nextra](https://nextra.vercel.app/), ...", I assumed it would be `Project` instead of `Projects`. I could be well wrong, but still drafted a PR for this. Please feel free to ignore/close the PR if it seems irrelevant. :smile: 