### PR TITLE
fix: Added redirects for missing repo content

### DIFF
--- a/packages/projects-docs/next.config.js
+++ b/packages/projects-docs/next.config.js
@@ -470,6 +470,46 @@ module.exports = withNextra({
         destination: "/learn/repositories/getting-started/repo-import",
         permanent: true,
       },
+      /*
+           Redirects for missing repo content that is available 
+           under devboxes
+           Not permanent redirection as content might change
+        */
+      {
+        source: "/learn/repositories/task",
+        destination: "/learn/devboxes/task",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/devtools",
+        destination: "/learn/devboxes/devtools",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/preview",
+        destination: "/learn/devboxes/preview",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/terminal",
+        destination: "/learn/devboxes/terminal",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/upload",
+        destination: "/learn/devboxes/upload",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/interactive-readme",
+        destination: "/learn/devboxes/interactive-readme",
+        permanent: false,
+      },
+      {
+        source: "/learn/repositories/secrets",
+        destination: "/learn/devboxes/secrets",
+        permanent: false,
+      },
     ];
   },
 });

--- a/packages/projects-docs/pages/learn/guides/_meta.json
+++ b/packages/projects-docs/pages/learn/guides/_meta.json
@@ -4,8 +4,8 @@
     "href": "/learn/repositories/getting-started/repo-import"
   },
   "your-first-sandbox": {
-    "title": "Getting started with sandboxes",
-    "href": "/learn/sandboxes/your-first-sandbox"
+    "title": "Getting started with devboxes",
+    "href": "/learn/devboxes/your-first-sandbox"
   },
   "setting-up-vscode": {
     "title": "Getting started with VS Code",

--- a/packages/projects-docs/pages/learn/repositories/_meta.json
+++ b/packages/projects-docs/pages/learn/repositories/_meta.json
@@ -6,6 +6,7 @@
   "task": "Task Configuration",
   "terminal": "Terminal",
   "interactive-readme": "Interactive Readme",
+  "secrets": "Secrets",
   "upload": "File Upload",
   "review": "Code Reviews",
   "open-source": "Open Source Collaboration",


### PR DESCRIPTION
Added redirects for missing repo content that is available under devboxes. Fixes the menu that points to 404.