### PR TITLE
style: Update link in usage-based billing page

### DIFF
--- a/packages/projects-docs/pages/learn/plans/usage-based-billing.mdx
+++ b/packages/projects-docs/pages/learn/plans/usage-based-billing.mdx
@@ -25,4 +25,4 @@ If the storage included in your subscription tier isn't enough, you can upgrade 
 
 
 
-Further details on how usage-based billing is used in our pricing can be found on the [Plans](/learn/plans/plans) page.
+Further details on how usage-based billing is used in our pricing can be found on the [Plans](/learn/plans/subscriptions) page.


### PR DESCRIPTION
Previous UBB redirect was to plans/plans from a previous naming convention

Updating to plans/subscriptions