### PR TITLE
Fixed broken link to Docs

### DIFF
--- a/packages/projects-docs/README.md
+++ b/packages/projects-docs/README.md
@@ -1,4 +1,4 @@
-# [CodeSandbox Docs](https://codesandbox.io/docs/learn/introduction)
+# [CodeSandbox Docs](https://codesandbox.io/docs/learn)
 
 The official documentation for CodeSandbox.
 


### PR DESCRIPTION
Current link is to a page that does not exist, since the introduction marked as a section on Nextra.