### PR TITLE
fix: Updating docs to point to new support form 

### DIFF
--- a/packages/projects-docs/pages/faq.mdx
+++ b/packages/projects-docs/pages/faq.mdx
@@ -61,7 +61,7 @@ There are a few possible reasons a repo might throw that error on import. The
 most common are: the lack of a `package.json` file, or the project using
 more than 500 modules (files).
 
-If you think it's something else, or you're unable to solve this yourself, then [get in touch](mailto:support@codesandbox.io)
+If you think it's something else, or you're unable to solve this yourself, then [get in touch using our support form](https://codesandbox.io/support)
 and provide a link to the repo you're importing and we can look into this for
 you.
 

--- a/packages/projects-docs/pages/learn/devboxes/devtools.mdx
+++ b/packages/projects-docs/pages/learn/devboxes/devtools.mdx
@@ -54,4 +54,4 @@ We are working on supporting other DevTools in the future, which may include:
 - [Postman](https://www.postman.com/) integration
 - Bundle size analyzer
 
-If you would like to collaborate on building a DevTool, please reach out to us at [support@codesandbox.io](mailto:support@codesandbox.io).
+If you would like to collaborate on building a DevTool, please select 'something else' on our [support form](https://codesandbox.io/support) and get in touch!

--- a/packages/projects-docs/pages/learn/environment/vm.mdx
+++ b/packages/projects-docs/pages/learn/environment/vm.mdx
@@ -26,7 +26,7 @@ VM resource consist of vCPU, RAM and memory. The vCPU and RAM specs are grouped 
 | Pro    | 50 GB     | 
 
 
-If you require storage that goes beyond our Pro plan defaults, [get in touch](mailto:support@codesandbox.io) and our team will adjust the limits to suit your project.
+If you require storage that goes beyond our Pro plan defaults, please select 'Pro Subscriptions' on our support form and [get in touch](https://codesandbox.io/support). Our team can adjust your limits to suit your project.
 
 ## Memory snapshotting
 

--- a/packages/projects-docs/pages/learn/integrations/tailscale.mdx
+++ b/packages/projects-docs/pages/learn/integrations/tailscale.mdx
@@ -114,4 +114,4 @@ The following example `.codesandbox/tasks.json` runs each of these commands as t
 Putting all of this together, CodeSandbox will automatically start your application using Docker Compose, include a Tailscale container, and initiate a connection based on your Auth Key.
 The running application will have access to private resources on your tailnet.
 
-If you enjoy using CodeSandbox and Tailscale, and would like to see deeper integration between these products in the future, please [reach out to us](mailto:support@codesandbox.io).
+If you enjoy using CodeSandbox and Tailscale, and would like to see deeper integration between these products in the future, please let us know using our [contact form](https://codesandbox.io/support)!

--- a/packages/projects-docs/pages/learn/sandboxes/custom-npm-registry.mdx
+++ b/packages/projects-docs/pages/learn/sandboxes/custom-npm-registry.mdx
@@ -118,7 +118,7 @@ behind a VPN out of the box. However, we do have three solutions:
 
 **Solution 1: bypass the proxy** We can bypass the proxy on our service to let
 the browser fetch from the registry directly. This is not enabled by default for
-everyone - please [request this be turned on](mailto:support@codesandbox.io).
+everyone - please [request this be turned on](https://codesandbox.io/support).
 The disadvantage of this approach is that you have to share your registry auth
 token with everyone who has access to the sandbox. Also, to make this work, you
 need to add CORS headers to your registry so the browser can fetch the packages
@@ -126,12 +126,12 @@ directly from our origin.
 
 **Solution 2: whitelist the proxy** Another solution is to whitelist the IP
 range of our proxy. We make sure that we keep the same IP for our proxy. Please
-[request these details](mailto:support@codesandbox.io).
+[request these details](https://codesandbox.io/support).
 
 **Solution 3: self-host the proxy** A third option is to self-host the proxy in
 your network, and letting the proxy communicate with our API server to validate
 the tokens that are sent in. We can
-[help get you setup with this](mailto:support@codesandbox.io).
+[help get you setup with this](https://codesandbox.io/support).
 
 ### Can I use a .npmrc file?
 


### PR DESCRIPTION
Updated support links to use support form instead of email in various pages