### PR TITLE
chore: update outdated FAQ

### DIFF
--- a/packages/projects-docs/pages/faq.mdx
+++ b/packages/projects-docs/pages/faq.mdx
@@ -32,11 +32,6 @@ Our editor may work on other operating systems and mobile devices. While we will
 
 There are several ways to set a sandbox as private. One universal way (that works both for sandboxes and devboxes) is to right-click a sandbox from the dashboard and select _Make sandbox private_.
 
-<Callout>
-A [Pro subscription](https://codesandbox.io/pricing) is required to
-make sandboxes private or unlisted.
-</Callout>
-
 You can also change the privacy settings from the editor. How you do it will depend on whether you're using a sandbox or a devbox, as shown below.
 
 ### Make a browser sandbox private


### PR DESCRIPTION
This PR removes an FAQ item that was deprecated by a recent pricing change.