### PR TITLE
remove ios in docs

### DIFF
--- a/packages/projects-docs/pages/faq.mdx
+++ b/packages/projects-docs/pages/faq.mdx
@@ -189,11 +189,9 @@ If you have additional questions or need support, please use the community [Disc
 
 ### What is the current state of CodeSandbox for iOS?
 
-CodeSandbox for iOS support and maintenance is currently suspended.
+CodeSandbox for iOS is no longer available.
 
-CodeSandbox is currently unable to update the iOS experience at the rate required to keep up with the changes happening on the web editor. As a result, we have decided to discontinue support for the iOS app until we are able to provide an experience on par with the web editor. This does not remove the app from your device or prevent you from opening it if you already have it installed.
-
-We will make a further announcement about the future of CodeSandbox for iOS by July 2024.
+CodeSandbox is currently unable to maintain the app experience and has removed it from the App Store. This does not remove the app from your device or prevent you from opening it if you already have it installed.
 
       ## Sandboxes
 

--- a/packages/projects-docs/pages/learn/repositories/collaborate-share.mdx
+++ b/packages/projects-docs/pages/learn/repositories/collaborate-share.mdx
@@ -3,15 +3,14 @@ title: Collaborate and Share
 description:
 ---
 
-
 # Collaborate & Share
+
 At CodeSandbox, we believe that collaborating on code should be as easy as possible.
 
 As we evolve our platform, we keep expanding how you can collaborate with others when coding.
 
-      
 ## Repositories & Devboxes
- 
+
 CodeSandbox Repositories and Devboxes were built to facilitate collaboration.
 
 Every branch you run on CodeSandbox gets its own live [development environment](/learn/environment/vm), which is fully collaborative by default. This means **you just have to share the URL of that branch to collaborate with others**.
@@ -21,23 +20,19 @@ When an Editor joins the branch you're on, you can follow their avatar through t
 This makes CodeSandbox Repositories the perfect tool to develop full-stack apps with your team, as you can grant access to all projects and branches or share specific branches with more granular permissions.
 
 ### Sharing specific branches
+
 1. Open the branch you wish to share in the **Editor**.
 2. In the top right corner, click on **`Share`** .
 3. Copy the URL to share your workspace.
 
 ### Working in teams
+
 For more information on managing and creating teams, go to the [Team](/learn/teams/permissions) page.
 
 ### Working on other IDEs
 
-Collaboration works on our VS Code extension and the CodeSandbox iOS App in a very similar fashion. Simply find the branch that you want to work on together, share the URL, and build together live.
+Collaboration works on our VS Code Desktop in a very similar fashion. Simply find the branch that you want to work on together, share the URL, and build together live.
 
 ### Devboxes
 
 Collaborating on Devboxes is almost identical to what we described above for Repositories. The main difference is the fact that Devboxes are an isolated instance that's not connected to GitHub, so there's no concept of a "branch".
-
-
-
-
-
-

--- a/packages/projects-docs/pages/learn/repositories/getting-started/configure-vscode.mdx
+++ b/packages/projects-docs/pages/learn/repositories/getting-started/configure-vscode.mdx
@@ -7,9 +7,9 @@ import { Callout } from 'nextra-theme-docs'
 
 ## VS Code Configuration
 
-CodeSandbox supports opening branches in [VS Code](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects) and in our [native iOS app](https://apps.apple.com/us/app/codesandbox/id1423330822). When you open the branch inside VS Code, you will have access to your own extensions, keybindings and themes.
+CodeSandbox supports opening branches in [VS Code Desktop](https://marketplace.visualstudio.com/items?itemName=CodeSandbox-io.codesandbox-projects). When you open the branch inside VS Code, you will have access to your own extensions, keybindings and themes.
 
-<Callout emoji="⭐">VS Code and iOS also have live collaboration across different editors. This means that you'll be able to work together with someone who has the same branch open inside the web editor.</Callout>
+<Callout emoji="⭐">VS Code Desktop also has live collaboration. This means that you'll be able to work together with someone who has the same branch open inside the web editor.</Callout>
 
 If you want to configure default VS Code extensions to be installed for your repository, you can create a new file called `.vscode/recommendations.json`.
 


### PR DESCRIPTION
- updates the FAQ on the status of iOS
- removes a few references to iOS left over in the docs