### PR TITLE
fix: update broken link and outdated content in Explore page

### DIFF
--- a/packages/projects-docs/pages/learn/_meta.json
+++ b/packages/projects-docs/pages/learn/_meta.json
@@ -29,5 +29,5 @@
     "title": "More"
   },
   "ci": "CodeSandbox CI",
-  "explore": "Explore Page & Curators"
+  "explore": "Discover Page"
 }

--- a/packages/projects-docs/pages/learn/explore.mdx
+++ b/packages/projects-docs/pages/learn/explore.mdx
@@ -1,38 +1,21 @@
 ---
-title: Explore Page & Curators
+title: Discover Page
 authors: ['CompuIves']
 description:
-  The explore page highlights interesting sandboxes created by the community.
+  The Discover page highlights interesting sandboxes created by the community.
   Find out how to get picked or become a curator.
 ---
 
-# Explore Page & Curators
+# Discover Page
 
-## Explore Page
+CodeSandbox features a [Discover page](https://codesandbox.io/discover). This page highlights some of the interesting Sandboxes and Devboxes created by members of the CodeSandbox community.
 
-CodeSandbox features an [explore page](https://codesandbox.io/dashboard/discover). This page highlights some of
-the interesting sandboxes created an curated by members of the CodeSandbox
-community.
+It also includes a powerful search option, which allows you to find all the public Sandboxes created by other CodeSandbox users.
 
-## What is a curator?
+## Which Sandboxes get picked?
 
-A curator is someone in the community who can pick sandboxes for the explore
-page. You can get an invitation to become a "curator" from staff or other
-curators. Everyone is applicable to become a curator, but we generally select
-people that are active on CodeSandbox or are knowledgeable in a specific field
-(eg. animations).
-
-If you're interested in becoming a curator, send us an e-mail at
-[mailto:curators@codesandbox.io](mailto:curators@codesandbox.io).
-
-## Which sandboxes get picked?
-
-Sandboxes get picked based on their content and/or appearance. This includes
-those with interesting logic or approach. As well as those that just look cool.
+The CodeSandbox team picks Sandboxes based on their content and/or appearance. This includes those with interesting logic or approach and those that just look cool.
 
 ## How can I get picked?
 
-We have a dashboard with popular sandboxes to pick from, but we also pick based
-on what we happen to see. We scour Twitter for sandboxes too, if you want to be
-picked we recommend you to mention us in a tweet
-[@codesandbox](https://twitter.com/codesandbox) with a link to your sandbox!
+We review Sandboxes submitted to us by users via email, but the best way to get our attention is to tweet about it and tag [@codesandbox](https://x.com/codesandbox).


### PR DESCRIPTION
The page was quite outdated and included references to Curators, which AFAIK are no longer active. This updated version points to the right URL and explains how the page gets populated with content.

Preview [here](https://pkvkvr-3000.csb.app/learn/explore).