### PR TITLE
chore: fix URL of CSB friends form

### DIFF
--- a/packages/projects-docs/pages/learn/plans/codesandbox-friends.mdx
+++ b/packages/projects-docs/pages/learn/plans/codesandbox-friends.mdx
@@ -15,15 +15,16 @@ Thank you for being part of our community!
 
 To qualify for the CodeSandbox Friends program, a project must fall into one of the following categories.
 
-- **Licensed open-source software**: Libraries, frameworks, and plugins that developers use to build applications. CodeSandbox may be used to develop and share documentation examples or to publish NPM packages for consumption by the community. Projects in this category must be publicly available with a valid Open Source license&ast;.
-- **Developer community projects**: Projects that offer tools, content and other resources for free to the developer community. This includes educational projects&ast;&ast; and resources that help people learn how to code.
+- **Licensed open-source software**: Libraries, frameworks, and plugins that developers use to build applications. CodeSandbox may be used to develop and share documentation examples or to publish NPM packages for consumption by the community. Projects in this category must be publicly available with a valid Open Source license\*.
+- **Developer community projects**: Projects that offer tools, content and other resources for free to the developer community. This includes educational projects\*\* and resources that help people learn how to code.
 - **Non-profit organizations**: Legally recognized non-profit and non-governmental organizations that use CodeSandbox to further their mission and improve the lives of the people they serve.
 
-_&ast;Open-source projects that are backed by for-profit organizations are unfortunately not eligible for CodeSandbox Friends. However, we may be able to offer a discounted <a href="https://codesandbox.io/enterprise">CodeSandbox Enterprise</a> plan._
+_\*Open-source projects that are backed by for-profit organizations are unfortunately not eligible for CodeSandbox Friends. However, we may be able to offer a discounted <a href="https://codesandbox.io/enterprise">CodeSandbox Enterprise</a> plan._
 
-_&ast;&ast;Educational courses or projects that require payment or that are part of a for-profit organization's offering (such as a fee-charging University) are not eligible for CodeSandbox Friends. We offer [education plans](/learn/plans/education-plans) specifically catered to students and educators who fit these parameters.
+\_\*\*Educational courses or projects that require payment or that are part of a for-profit organization's offering (such as a fee-charging University) are not eligible for CodeSandbox Friends. We offer [education plans](/learn/plans/education-plans) specifically catered to students and educators who fit these parameters.
 
 ## Application Requirements
+
 - Projects that are backed or owned by for-profit companies, even if open-source, are not eligible for CodeSandbox Friends.
 - Applicants need to be the owner of the Project/Repository. Owners can invite contributors to the Friends workspace when their application is approved.
 - Applicants need to apply once per 'CodeSandbox Friends' project. Any applications linking multiple projects will automatically be rejected.
@@ -37,9 +38,10 @@ All CodeSandbox workspaces that are approved as CodeSandbox Friends receive the 
 - Unlimited number of Sandboxes on the eligible workspace.
 - Special access to upcoming updates to our Sandbox API.
 
-You can apply [here](https://codesandbox.typeform.com/friends).
+You can apply through our [Support form](https://codesandbox.io/support) (make sure to select "CodeSandbox Friends").
 
 ### Notes and Disclaimer
+
 - CodeSandbox Friends workspaces must **only** be used for the approved project. If we discover that the workspace is being used for other projects, we reserve the right to remove access to CodeSandbox Friends benefits without notice.
 - There are no limits on the number of CodeSandbox Friends workspaces that you can own or be a member of at this time.
 - Unless clearly stated otherwise, CodeSandbox Friends benefits and discounts are not cumulative with any other promotions.


### PR DESCRIPTION
The old URL was leading to a broken Typeform.