### PR TITLE
Improvements to SDK FAQs

### DIFF
--- a/packages/projects-docs/pages/sdk/faq.mdx
+++ b/packages/projects-docs/pages/sdk/faq.mdx
@@ -19,11 +19,17 @@ To revoke an API key, go to the "Permissions" tab of your [Workspace Settings](h
 
 Please subscribe to a CodeSandbox plan that includes the most suitable rate limit for you. In case you're on our Builder plan already, please [contact us](https://webforms.pipedrive.com/f/72gS7iXoP8qjL8Ku9HZQcN5UKpUpZkgKRCjhbqREjCOYyBgzrCKCr7Mys5AyczOHBN) to discuss an Enterprise plan.
 
+## My iframe previews always show a confirmation prompt. Can I remove this?
+
+Yes! This prompt has been implemented as a part of our phishing prevention measures. You can remove it by taking out any [Pro plan](https://codesandbox.io/pricing) on the account that you're using with CodeSandbox SDK.
+
 ## Can I change the specs of the VMs?
 
-Currently, we only allow changing the default specs for all VMs created with the SDK. You can change
+Currently, we only allow changing the default specs for all VMs created with the SDK. You can change your VM tier using the steps detailed [here](https://codesandbox.io/docs/sdk/specs)
 
-We are also SOC 2 Type II compliant.
+## Are VMs created by the SDK covered by any cybersecurity certifications?
+
+CodeSandbox and it's infrastructure, including VMs are SOC 2 Type II compliant. You can read our SOC 2 announcement on our [blog](https://codesandbox.io/blog/codesandbox-is-now-soc-2-compliant)
 
 ## Is it possible to self-host CodeSandbox SDK?
 
@@ -39,4 +45,4 @@ Yes. Your CodeSandbox plan will allow you to use both, so you can leverage the S
 
 ## Does the CodeSandbox SDK use CodeSandbox Sandboxes or Devboxes?
 
-While the SDK code only mentions "sandbox", the actual environments that it uses are officially called "Devboxes" (which use VMs). So, if you need more details about these VMs, please always refer to "[Devbox](/learn/devboxes/overview)" section of the CodeSandbox documentation and pricing.
+While the SDK code only mentions "sandbox", the actual environments that it uses are officially called "Devboxes" (which use VMs). If you need more details about these VMs, please refer to the "[Devbox](/learn/devboxes/overview)" section of the CodeSandbox documentation for further information and pricing.


### PR DESCRIPTION
- Fixing unfinished sentence in VM spec selection question
- Adding clarification about confirmation prompt in previews
- Separating out SOC2 certification into own FAQ item 