### PR TITLE
fix: update link to point to new together docs page

### DIFF
--- a/packages/projects-docs/pages/sdk/use-cases.mdx
+++ b/packages/projects-docs/pages/sdk/use-cases.mdx
@@ -37,7 +37,7 @@ CodeSandbox SDK allows programmatically spinning up sandboxes (VMs) to execute c
 
 As these sandboxes exist in total isolation, you can run untrusted code without worrying about it affecting your system.
 
-Many early adopters, such as Blackbox AI, are leveraging the power of CodeSandbox SDK to bring code interpretation capabilities to their generative AI applications. We highly recommend following the [guide by Together AI](https://docs.together.ai/docs/code-execution) to get CodeSandbox SDK running seamlessly with any of the leading open-source LLMs.
+Many early adopters, such as Blackbox AI, are leveraging the power of CodeSandbox SDK to bring code interpretation capabilities to their generative AI applications. We highly recommend following the [guide by Together AI](https://docs.together.ai/docs/together-code-sandbox) to get CodeSandbox SDK running seamlessly with any of the leading open-source LLMs.
 
 ## CI/CD
 


### PR DESCRIPTION
When reading the docs I ran into a 404. This fix points to a working page.