### PR TITLE
updates

### DIFF
--- a/packages/projects-docs/pages/sdk/clients.mdx
+++ b/packages/projects-docs/pages/sdk/clients.mdx
@@ -13,6 +13,10 @@ There are three different ways to connect to a Sandbox:
 - **Node**: When you want to connect to a Sandbox from a Node client environment, for example React Native
 - **Browser**: When you want to connect to a Sandbox from a browser client environment
 
+<Callout>
+The browser and node clients use the same unified implementation, providing consistent behavior across both environments.
+</Callout>
+
 ## SDK
 
 On your server, where you use the SDK, you can connect directly to a Sandbox:

--- a/packages/projects-docs/pages/sdk/create-resume.mdx
+++ b/packages/projects-docs/pages/sdk/create-resume.mdx
@@ -23,7 +23,7 @@ const sandbox = await sdk.sandboxes.create();
 ```
 
 <Callout>
-By default Sandboxes are `unlisted` and can be accessed and forked by anyone with a url. If you want to create a private sandbox you can pass `privacy: 'private'`, which requires host tokens to access the exposed ports.
+By default Sandboxes are `public` and can be accessed and forked by anyone with a url on CodeSandbox. Available privacy options are `private`, `public-hosts`, or `public`. Private sandboxes require host tokens to access exposed ports.
 </Callout>
 
 If no `id` option is provided to `sandbox.create()`, we'll create a sandbox forked from our [Universal](https://codesandbox.io/p/devbox/universal-pcz35m) template on CodeSandbox. You can also pass in a specific template id from [our collection of templates](/sdk/snapshot-library) or by creating your own template using our [Template Builder](/sdk/templates).
@@ -37,7 +37,7 @@ const sandbox = await sdk.sandboxes.create({
     description: 'My sandbox',
     tags: ['my-tag'],
 
-    // Public, unlisted or private
+    // Privacy options: 'private', 'public-hosts', or 'public'
     privacy: 'private',
 
     // Collection folder on Dashboard
@@ -66,6 +66,27 @@ const sandbox = await sdk.sandboxes.create({
 <Callout>
 The `automaticWakeupConfig` only wakes up the Sandbox, it does not extend its hibernation timeout.
 </Callout>
+
+## Get an Existing Sandbox
+
+To get information about an existing sandbox without resuming it, use `sdk.sandboxes.get(id)`:
+
+```ts
+const sandbox = await sdk.sandboxes.get('sandbox-id');
+```
+
+This method retrieves sandbox metadata and status without waking up a hibernated sandbox.
+
+## List Running Sandboxes
+
+To get a list of all currently running sandboxes, use `sdk.sandboxes.listRunning()`:
+
+```ts
+const runningSandboxes = await sdk.sandboxes.listRunning();
+console.log(runningSandboxes); // Array of sandbox objects
+```
+
+This method returns an array of sandbox objects that are currently active and running.
 
 ## Resume an Existing Sandbox
 

--- a/packages/projects-docs/pages/sdk/hosts.mdx
+++ b/packages/projects-docs/pages/sdk/hosts.mdx
@@ -22,5 +22,5 @@ console.log(url)
 ```
 
 <Callout>
-By default all Sandboxes are unlisted, but you need to use host tokens to access private Sandboxes. With public or unlisted Sandboxes the host tokens are not necessary, but you can still `getUrl` to generate a url for the relevant port.
+By default all Sandboxes are public, but you need to use host tokens to access private Sandboxes. With public or public-hosts Sandboxes the host tokens are not necessary, but you can still `getUrl` to generate a url for the relevant port.
 </Callout>

--- a/packages/projects-docs/pages/sdk/index.mdx
+++ b/packages/projects-docs/pages/sdk/index.mdx
@@ -40,6 +40,22 @@ const output = await client.commands.run("echo 'Hello World'");
 console.log(output) // Hello World
 ```
 
+### OpenTelemetry Support
+
+You can pass an OpenTelemetry tracer to the CodeSandbox constructor to enable tracing for all SDK operations:
+
+```js
+import { CodeSandbox } from "@codesandbox/sdk";
+import { trace } from "@opentelemetry/api";
+
+const tracer = trace.getTracer('my-app');
+const sdk = new CodeSandbox(process.env.CSB_API_KEY, {
+  tracer
+});
+```
+
+This will automatically trace all Sandboxes, Sandbox, and SandboxClient methods, including modules.
+
 ## How it works
 
 The SDK can spin up a sandbox by cloning a template in under 3 seconds. Inside this VM you have a full development environment.

--- a/packages/projects-docs/pages/sdk/templates.mdx
+++ b/packages/projects-docs/pages/sdk/templates.mdx
@@ -58,7 +58,7 @@ $ CSB_API_KEY=your-api-key npx @codesandbox/sdk build ./my-template --privacy pr
 ```
 
 <Callout>
-The template defaults to a `Micro` VM Tier for both building the template and when creating Sandboxes from it. You can not "downsize" Sandboxes when creating them from a template, so make sure you set the minimum tier you want here. It is recommended to make templates private, but they default to "unlisted". Use `build --help` for documentation on all parameters.
+The template defaults to a `Micro` VM Tier for both building the template and when creating Sandboxes from it. You can not "downsize" Sandboxes when creating them from a template, so make sure you set the minimum tier you want here. It is recommended to make templates private, but they default to "public". Use `build --help` for documentation on all parameters.
 </Callout>
 
 This will start the process of creating Sandboxes for each of our clusters, write files, restart, wait for port 5173 to be available and then hibernate. This generates the snapshot that allows you to quickly create Sandboxes already running a dev server from the template.


### PR DESCRIPTION
Related to:

:rocket: So I just published 2.1.0-rc.2 (Already tested something on rc.1). I'll prep a documentation update while users are testing. It has the following updates:

- You can now fetch a single Sandbox with sdk.sandboxes.get(sanboxId)
- You can now list running Sandboxes using the SDK with sdk.sandboxes.listRunning()
- You can now pass an OpenTelemetry tracer to new CodeSandbox({ tracer }) . It traces all Sandboxes, Sandbox and SandboxClient (with modules) methods
- You now pass private, public-hosts or public as privacy option on sdk.sandboxes.create() . unlisted has been deprecated and public now acts as unlisted (Cause there is no need to put SDK Sandboxes in the CodeSandbox Universe or use the term unlisted with the SDK)

Additionally we have completely decoupled the original pitcher-client SDK from the new SDK. The browser client now uses the same implementation as the node client, no more licensing differences and we have officially cut the umbilical cord and SDK is a standalone codebase.