### PR TITLE
Remove playground entry from SDK metadata

### DIFF
--- a/packages/projects-docs/pages/sdk/_meta.json
+++ b/packages/projects-docs/pages/sdk/_meta.json
@@ -1,10 +1,6 @@
 {
   "index": "Introduction",
   "use-cases": "Use Cases",
-  "playground": {
-    "href": "https://wkyxcw-5173.csb.app/",
-    "title": "Example Playground"
-  },
   "faq": "FAQ",
   "pricing": "Pricing",
   "-- guides": {


### PR DESCRIPTION
Removed playground section from _meta.json as it is a bad showcase and will shortly be replaced by a link to an implementation using the SDK instead