### PR TITLE
add repo migration guide

### DIFF
--- a/packages/projects-docs/pages/learn/repositories/_meta.json
+++ b/packages/projects-docs/pages/learn/repositories/_meta.json
@@ -1,4 +1,5 @@
 {
+  "migration-guide": "Migration Guide",
   "overview": "Overview",
   "getting-started": "Getting Started",
   "devtools": {

--- a/packages/projects-docs/pages/learn/repositories/collaborate-share.mdx
+++ b/packages/projects-docs/pages/learn/repositories/collaborate-share.mdx
@@ -3,7 +3,13 @@ title: Collaborate and Share
 description:
 ---
 
+import { Callout } from 'nextra-theme-docs'
+
 # Collaborate & Share
+
+<Callout type="warning">
+**Deprecation notice:** CodeSandbox Repositories will no longer accept new imports starting April 1, 2026. Full support for repositories will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition to GitHub Codespaces.
+</Callout>
 
 At CodeSandbox, we believe that collaborating on code should be as easy as possible.
 

--- a/packages/projects-docs/pages/learn/repositories/getting-started/repo-import.mdx
+++ b/packages/projects-docs/pages/learn/repositories/getting-started/repo-import.mdx
@@ -7,6 +7,10 @@ import { Callout } from 'nextra-theme-docs'
 
 # Import a repository
 
+<Callout type="warning">
+**Deprecation notice:** CodeSandbox Repositories will no longer accept new imports starting April 1, 2026. Full support for repositories will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition to GitHub Codespaces.
+</Callout>
+
 If you haven't already imported a repository, you can do so by navigating to the [Recent page](https://codesandbox.io/dashboard/recent) in the dashboard and clicking `+ Repository`.
 
 If you have already granted GH OAuth permissions, you will see a list of GitHub organizations that you are a part of.

--- a/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
+++ b/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
@@ -24,7 +24,7 @@ Before you start, here's how CodeSandbox concepts translate to Codespaces.
 | Sandbox | Codespace | A Sandbox is the branch. A Codespace is an instance of a branch. |
 | Forking a Sandbox | Creating a branch | In Codespaces, you create a git branch first, then launch a container for it. |
 | VM Snapshot | Prebuilds | CodeSandbox saves memory state. Codespaces pre-installs dependencies so you start fast. |
-| `.codesandbox/tasks.json` | `devcontainer.json` | CodeSandbox uses a dedicated tasks file. Codespaces uses `postCreateCommand` or `postStartCommand`. |
+| `.codesandbox/tasks.json` | `.devcontainer/devcontainer.json` | CodeSandbox uses a dedicated tasks file. Codespaces uses `postCreateCommand` or `postAttachCommand`. |
 
 ## Transitioning the "instant" workflow
 
@@ -45,18 +45,18 @@ In CodeSandbox Repositories, you visit the main branch and the VM is already run
 1. Open VS Code locally.
 2. Use the GitHub Codespaces extension to create or connect to environments directly.
 
-**Warm starts via Prebuilds:**
+## Step-by-step: starting a feature
 
-To replicate the "instant" feel where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
+### Step 1: Set up Prebuilds (Prerequisite)
+
+To replicate the "instant" feel of CodeSandbox where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
 
 1. Go to your repository on GitHub.
 2. Navigate to **Settings** > **Codespaces**.
 3. Under **Prebuild configuration**, click **Set up prebuild**.
 4. Select the branch and region, then save.
 
-## Step-by-step: starting a feature
-
-### Step 1: Create a branch and Codespace
+### Step 2: Create a branch and Codespace
 
 In CodeSandbox, you "Forked" to branch. In the new workflow:
 
@@ -64,32 +64,36 @@ In CodeSandbox, you "Forked" to branch. In the new workflow:
 2. Create a new branch (e.g., `feat/new-ui`).
 3. Click **Code** > **Codespaces** > **+**.
 
-### Step 2: Move tasks to `devcontainer.json`
+### Step 3: Move tasks to `.devcontainer/devcontainer.json`
 
-Since you no longer have a `.codesandbox/tasks.json`, move those commands into the `devcontainer.json` lifecycle hooks.
+Since you no longer have a `.codesandbox/tasks.json`, move those commands into the `.devcontainer/devcontainer.json` lifecycle hooks.
 
 **Where your commands go:**
 
-| CodeSandbox (`tasks.json`) | Codespaces (`devcontainer.json`) |
+| CodeSandbox (`.codesandbox/tasks.json`) | Codespaces (`.devcontainer/devcontainer.json`) |
 | --- | --- |
 | `setupTasks` | `"postCreateCommand": "npm install"` |
-| `runTasks` | `"postStartCommand": "npm start"` |
+| `runTasks` | `"postAttachCommand": "npm start"` |
 
-**Example `devcontainer.json`:**
+**Example `.devcontainer/devcontainer.json`:**
 
 ```json
 {
   "name": "My Project",
   "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
   "postCreateCommand": "npm install",
-  "postStartCommand": "npm start",
+  "postAttachCommand": "npm start",
   "forwardPorts": [3000]
 }
 ```
 
+<Callout emoji="⭐">
+**Note:** Use `postAttachCommand` (not `postStartCommand`) for tasks that should run each time you connect to the Codespace. This ensures your dev server starts automatically when you open the environment.
+</Callout>
+
 Place this file at `.devcontainer/devcontainer.json` in your repository root.
 
-### Step 3: Connect from VS Code desktop
+### Step 4: Connect from VS Code desktop
 
 The Codespaces extension is built into VS Code:
 
@@ -97,6 +101,10 @@ The Codespaces extension is built into VS Code:
 2. Click the **Remote Explorer** icon (bottom-left green icon or sidebar).
 3. Select **GitHub Codespaces**.
 4. Your environment will be listed. Click to connect.
+
+<Callout emoji="⚠️">
+**Important:** A branch must already exist on GitHub before you can connect Codespaces to it. If you don't see your branch, create it first—either locally and push it to GitHub, or create it directly on GitHub.
+</Callout>
 
 ## Key differences to know
 

--- a/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
+++ b/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
@@ -47,24 +47,7 @@ In CodeSandbox Repositories, you visit the main branch and the VM is already run
 
 ## Step-by-step: starting a feature
 
-### Step 1: Set up Prebuilds (Prerequisite)
-
-To replicate the "instant" feel of CodeSandbox where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
-
-1. Go to your repository on GitHub.
-2. Navigate to **Settings** > **Codespaces**.
-3. Under **Prebuild configuration**, click **Set up prebuild**.
-4. Select the branch and region, then save.
-
-### Step 2: Create a branch and Codespace
-
-In CodeSandbox, you "Forked" to branch. In the new workflow:
-
-1. Go to the GitHub repository.
-2. Create a new branch (e.g., `feat/new-ui`).
-3. Click **Code** > **Codespaces** > **+**.
-
-### Step 3: Move tasks to `.devcontainer/devcontainer.json`
+### Step 1: Move tasks to `.devcontainer/devcontainer.json`
 
 Since you no longer have a `.codesandbox/tasks.json`, move those commands into the `.devcontainer/devcontainer.json` lifecycle hooks.
 
@@ -93,7 +76,26 @@ Since you no longer have a `.codesandbox/tasks.json`, move those commands into t
 
 Place this file at `.devcontainer/devcontainer.json` in your repository root.
 
-### Step 4: Connect from VS Code desktop
+### Step 2: Set up Prebuilds
+
+To replicate the "instant" feel of CodeSandbox where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings** > **Codespaces**.
+3. Under **Prebuild configuration**, click **Set up prebuild**.
+4. Select the branch and region, then save.
+
+### Step 3: Create a branch and Codespace
+
+In CodeSandbox, you "Forked" to branch. In the new workflow, you can create a Codespace from either the web or VS Code desktop.
+
+#### From the web
+
+1. Go to the GitHub repository.
+2. Create a new branch (e.g., `feat/new-ui`).
+3. Click **Code** > **Codespaces** > **+**.
+
+#### From VS Code desktop
 
 The Codespaces extension is built into VS Code:
 

--- a/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
+++ b/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
@@ -1,0 +1,132 @@
+---
+title: Migration Guide
+description: How to migrate from CodeSandbox Repositories to GitHub Codespaces.
+---
+
+import { Callout } from 'nextra-theme-docs'
+
+# Migration guide: CodeSandbox Repos to GitHub Codespaces
+
+<Callout type="warning">
+CodeSandbox Repositories will no longer accept new imports starting **April 1, 2026**. Full support for repositories will end on **July 1, 2026**. We recommend migrating to GitHub Codespaces before these dates.
+</Callout>
+
+This guide walks you through moving your development workflow from CodeSandbox Repositories to GitHub Codespaces. The transition should take about 30 minutes for most projects.
+
+If you need help at any point, reach out to [support@codesandbox.io](mailto:support@codesandbox.io).
+
+## Vocabulary mapping
+
+Before you start, here's how CodeSandbox concepts translate to Codespaces.
+
+| CodeSandbox | Codespaces | Difference |
+| --- | --- | --- |
+| Sandbox | Codespace | A Sandbox is the branch. A Codespace is an instance of a branch. |
+| Forking a Sandbox | Creating a branch | In Codespaces, you create a git branch first, then launch a container for it. |
+| VM Snapshot | Prebuilds | CodeSandbox saves memory state. Codespaces pre-installs dependencies so you start fast. |
+| `.codesandbox/tasks.json` | `devcontainer.json` | CodeSandbox uses a dedicated tasks file. Codespaces uses `postCreateCommand` or `postStartCommand`. |
+
+## Transitioning the "instant" workflow
+
+### What you're used to (CodeSandbox)
+
+In CodeSandbox Repositories, you visit the main branch and the VM is already running with your tasks (like `npm start`) pre-executed. If you want to make changes, you click "Branch," which clones the running VM state into a new branch and URL instantly.
+
+### The new way (GitHub Codespaces)
+
+**From the browser:**
+
+1. Navigate to your repo on GitHub.
+2. Create a new branch.
+3. Click **Code** and then **Create Codespace on [branch]** for the full VM.
+
+**From VS Code desktop:**
+
+1. Open VS Code locally.
+2. Use the GitHub Codespaces extension to create or connect to environments directly.
+
+**Warm starts via Prebuilds:**
+
+To replicate the "instant" feel where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings** > **Codespaces**.
+3. Under **Prebuild configuration**, click **Set up prebuild**.
+4. Select the branch and region, then save.
+
+## Step-by-step: starting a feature
+
+### Step 1: Create a branch and Codespace
+
+In CodeSandbox, you "Forked" to branch. In the new workflow:
+
+1. Go to the GitHub repository.
+2. Create a new branch (e.g., `feat/new-ui`).
+3. Click **Code** > **Codespaces** > **+**.
+
+### Step 2: Move tasks to `devcontainer.json`
+
+Since you no longer have a `.codesandbox/tasks.json`, move those commands into the `devcontainer.json` lifecycle hooks.
+
+**Where your commands go:**
+
+| CodeSandbox (`tasks.json`) | Codespaces (`devcontainer.json`) |
+| --- | --- |
+| `setupTasks` | `"postCreateCommand": "npm install"` |
+| `runTasks` | `"postStartCommand": "npm start"` |
+
+**Example `devcontainer.json`:**
+
+```json
+{
+  "name": "My Project",
+  "image": "mcr.microsoft.com/devcontainers/javascript-node:20",
+  "postCreateCommand": "npm install",
+  "postStartCommand": "npm start",
+  "forwardPorts": [3000]
+}
+```
+
+Place this file at `.devcontainer/devcontainer.json` in your repository root.
+
+### Step 3: Connect from VS Code desktop
+
+The Codespaces extension is built into VS Code:
+
+1. Open VS Code locally.
+2. Click the **Remote Explorer** icon (bottom-left green icon or sidebar).
+3. Select **GitHub Codespaces**.
+4. Your environment will be listed. Click to connect.
+
+## Key differences to know
+
+### Persistence
+
+In CodeSandbox, every change is "live." In Codespaces, your work is saved in the cloud VM, but you still need to **commit and push** for others to see changes in the repository.
+
+### Secrets and environment variables
+
+Move your sandbox environment variables to GitHub Codespaces Secrets:
+
+1. Go to GitHub **Settings** > **Codespaces** > **Secrets**.
+2. Click **New secret**.
+3. Add your key-value pairs and select which repositories can access them.
+
+### Collaboration
+
+CodeSandbox is "live" by default with real-time multiplayer. For Codespaces, use the **Live Share** extension within your Codespace to collaborate in real-time:
+
+1. Install the Live Share extension (it may already be included).
+2. Click **Live Share** in the bottom status bar.
+3. Share the generated link with collaborators.
+
+## Timeline
+
+| Date | What happens |
+| --- | --- |
+| **April 1, 2026** | New repository imports are disabled. Existing repositories continue to work. |
+| **July 1, 2026** | Full support for CodeSandbox Repositories ends. |
+
+## Need help?
+
+If you run into issues during migration or have questions about your specific setup, contact us at [support@codesandbox.io](mailto:support@codesandbox.io).

--- a/packages/projects-docs/pages/learn/repositories/open-source.mdx
+++ b/packages/projects-docs/pages/learn/repositories/open-source.mdx
@@ -7,6 +7,10 @@ import { Callout } from 'nextra-theme-docs'
 
 # Open Source Collaboration
 
+<Callout type="warning">
+**Deprecation notice:** CodeSandbox Repositories will no longer accept new imports starting April 1, 2026. Full support for repositories will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition to GitHub Codespaces.
+</Callout>
+
 Working with your favorite open-source repositories is easier with CodeSandbox. Whether you are just checking out a repository, testing out an idea or formally proposing a feature, CodeSandbox can eliminate tedious steps in your process and get you working on your ideas faster.
 
 ## Viewing open-source repositories

--- a/packages/projects-docs/pages/learn/repositories/overview.mdx
+++ b/packages/projects-docs/pages/learn/repositories/overview.mdx
@@ -8,6 +8,10 @@ import { Callout } from 'nextra-theme-docs'
 
 # CodeSandbox Repositories
 
+<Callout type="warning">
+**Deprecation notice:** CodeSandbox Repositories will no longer accept new imports starting April 1, 2026. Full support for repositories will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition to GitHub Codespaces.
+</Callout>
+
 CodeSandbox allows you to instantly spin up a cloud development environment for any branch in your GitHub repository. It has a focus on speed and collaboration and allows you to create a workspace to be experienced by multiple people at the same time.
 
 ## Tailored for your project

--- a/packages/projects-docs/pages/learn/repositories/review.mdx
+++ b/packages/projects-docs/pages/learn/repositories/review.mdx
@@ -7,6 +7,10 @@ import { Callout } from 'nextra-theme-docs'
 
 # Using CodeSandbox for PR reviews
 
+<Callout type="warning">
+**Deprecation notice:** CodeSandbox Repositories will no longer accept new imports starting April 1, 2026. Full support for repositories will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition to GitHub Codespaces.
+</Callout>
+
 <Callout>
 PR Reviews are currently only available for GitHub repositories.
 </Callout>


### PR DESCRIPTION
 Summary                                                                                                                                                                                 
                                                                                                                                                                                          
  - Added a migration guide page (migration-guide.mdx) to the Repositories section covering vocabulary mapping, workflow transition, devcontainer.json setup, and key differences between 
  CodeSandbox Repos and GitHub Codespaces                                                                                                                                                 
  - Added deprecation warning callouts linking to the migration guide on all repository doc pages: overview, PR reviews, open source, collaborate & share, and repo import                
  - Updated _meta.json to surface the migration guide as the first item in the Repositories sidebar                                                                                       
                                                                                                                                                                                          
  Context

  CodeSandbox Repositories will stop accepting new imports on April 1, 2026 and fully shut down on July 1, 2026. This PR ensures users see the deprecation notice wherever they encounter
  repository docs and have a clear path to migrate.

  Test plan

  - Verify the migration guide renders correctly at /learn/repositories/migration-guide
  - Confirm the warning callout appears on all repository pages
  - Check that the sidebar nav shows "Migration Guide" as the first item under Repositories
  - Verify all internal links resolve correctly