### PR TITLE
docs: reorganize migration guide steps

### DIFF
--- a/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
+++ b/packages/projects-docs/pages/learn/repositories/migration-guide.mdx
@@ -47,24 +47,7 @@ In CodeSandbox Repositories, you visit the main branch and the VM is already run
 
 ## Step-by-step: starting a feature
 
-### Step 1: Set up Prebuilds (Prerequisite)
-
-To replicate the "instant" feel of CodeSandbox where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
-
-1. Go to your repository on GitHub.
-2. Navigate to **Settings** > **Codespaces**.
-3. Under **Prebuild configuration**, click **Set up prebuild**.
-4. Select the branch and region, then save.
-
-### Step 2: Create a branch and Codespace
-
-In CodeSandbox, you "Forked" to branch. In the new workflow:
-
-1. Go to the GitHub repository.
-2. Create a new branch (e.g., `feat/new-ui`).
-3. Click **Code** > **Codespaces** > **+**.
-
-### Step 3: Move tasks to `.devcontainer/devcontainer.json`
+### Step 1: Move tasks to `.devcontainer/devcontainer.json`
 
 Since you no longer have a `.codesandbox/tasks.json`, move those commands into the `.devcontainer/devcontainer.json` lifecycle hooks.
 
@@ -93,7 +76,26 @@ Since you no longer have a `.codesandbox/tasks.json`, move those commands into t
 
 Place this file at `.devcontainer/devcontainer.json` in your repository root.
 
-### Step 4: Connect from VS Code desktop
+### Step 2: Set up Prebuilds
+
+To replicate the "instant" feel of CodeSandbox where you don't wait for `npm install`, enable Prebuilds in your GitHub repo settings. This tells GitHub to run your setup scripts every time code is pushed, so the container is ready when you open it.
+
+1. Go to your repository on GitHub.
+2. Navigate to **Settings** > **Codespaces**.
+3. Under **Prebuild configuration**, click **Set up prebuild**.
+4. Select the branch and region, then save.
+
+### Step 3: Create a branch and Codespace
+
+In CodeSandbox, you "Forked" to branch. In the new workflow, you can create a Codespace from either the web or VS Code desktop.
+
+#### From the web
+
+1. Go to the GitHub repository.
+2. Create a new branch (e.g., `feat/new-ui`).
+3. Click **Code** > **Codespaces** > **+**.
+
+#### From VS Code desktop
 
 The Codespaces extension is built into VS Code:
 


### PR DESCRIPTION
## Summary

This PR reorganizes the migration guide steps in  to provide a more logical flow for users migrating from CodeSandbox Repositories to GitHub Codespaces.

## Changes

### Step Order Reorganization

The steps have been reordered to follow a more intuitive sequence:

1. **Step 1: Move tasks to ** - This is now the first step since configuring the devcontainer is a prerequisite for the subsequent steps.

2. **Step 2: Set up Prebuilds** - Moved to second position since prebuilds depend on having the devcontainer configuration in place.

3. **Step 3: Create a branch and Codespace** - Combined the previous "Create a branch" and "Connect from VS Code desktop" steps into one comprehensive step with sub-sections:
   - **From the web** - Instructions for creating a Codespace via GitHub.com
   - **From VS Code desktop** - Instructions for using the VS Code Codespaces extension

## Rationale

The previous order had users setting up prebuilds before configuring the devcontainer, which doesn't make sense since prebuilds rely on the devcontainer configuration. The new order follows a logical sequence:

1. Configure the environment (devcontainer.json)
2. Enable faster startup (prebuilds)
3. Start developing (create branch and codespace)

## Testing

- Verified the markdown renders correctly
- Confirmed all Callout components are properly formatted
- Steps flow logically from configuration to usage