### PR TITLE
docs: add deprecation banner for Devboxes (VM Sandboxes)

### DIFF
--- a/packages/projects-docs/pages/learn/vm-sandboxes/overview.mdx
+++ b/packages/projects-docs/pages/learn/vm-sandboxes/overview.mdx
@@ -9,6 +9,10 @@ import { Callout } from 'nextra-theme-docs'
 # VM Sandboxes 
 ### (Previously Devboxes)
 
+<Callout type="warning">
+**Deprecation notice:** Devboxes (now VM Sandboxes) are being deprecated. New Devboxes will no longer be available starting April 1, 2026, and full support will end on July 1, 2026. Please review our [migration guide](/learn/repositories/migration-guide) to transition your workloads.
+</Callout>
+
 CodeSandbox provides two development environments that are ideal for prototyping and rapid web development: [VM Sandboxes](/learn/vm-sandboxes/overview) and [Browser Sandboxes](/learn/browser-sandboxes/templates).
 
 We generally recommend using VM Sandboxes, which provide all the tooling needed for building prototypes. Sandboxes are mostly useful as a playground for basic front-end JavaScript projects.


### PR DESCRIPTION
## What

Adds a deprecation banner to the **VM Sandboxes (Previously Devboxes)** overview page, announcing the deprecation of the Devboxes product.

The banner uses the same `<Callout type="warning">` pattern introduced in the recent [Repositories deprecation notice](https://github.com/codesandbox/docs/pull/319) for visual consistency.

## Where

[`packages/projects-docs/pages/learn/vm-sandboxes/overview.mdx`](packages/projects-docs/pages/learn/vm-sandboxes/overview.mdx) — placed directly under the page title, above the intro copy.

## ⚠️ Needs confirmation before merge

The banner currently contains **placeholder dates and a migration target** that I could not verify from the repo:

- "New Devboxes unavailable starting **April 1, 2026**"
- "Full support ends **July 1, 2026**"
- Links to the existing [Repositories migration guide](/learn/repositories/migration-guide)

Please update these to the real deprecation timeline and the correct migration destination for Devboxes before merging.

🤖 Generated with [Claude Code](https://claude.com/claude-code)